### PR TITLE
docs: refocus roadmap on CMS fundamentals and MCP

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,63 @@
+# BareCMS plan
+
+A bare, MCP-native CMS.
+
+> BareCMS is the minimal CMS your AI agents talk to. It does not add AI buttons to the editor. AI tools (Claude, Cursor, Vikusha) already do that better. BareCMS gives them a clean MCP interface to your content.
+
+## Positioning
+
+Most CMSes are racing to add AI features inside their editors. BareCMS goes the other direction.
+
+- **Bare**. No editor bloat.
+- **MCP-native**. Composes with the AI tools users already have.
+- **Self-hostable**. Your content, your infra.
+- **Solo-friendly pricing**. Built for freelancers and indie developers.
+
+## Phases
+
+1. Bare basics (~4-6 weekends)
+2. MCP-native pivot (~1-2 weekends)
+3. SaaS MVP (~3-4 weekends)
+4. Growth, gated on paid demand
+
+See `roadmap.md` for tasks.
+
+## Out of scope
+
+- Granular role permissions and custom roles
+- Audit logs
+- Webhooks (replaced by MCP server)
+- Template marketplace (one good starter is enough)
+- Editor AI buttons (handled by external agents over MCP)
+- Page builder and drag-and-drop
+- Plugin ecosystem
+
+If a project needs those, Strapi or Sanity are better fits.
+
+## Pricing
+
+| Tier | Price | Includes |
+|---|---|---|
+| Self-hosted | Free | Full features, your infra, no support |
+| Solo (cloud) | $15/mo | 3 sites, local storage, single user, MCP access |
+| Team (cloud) | $30/mo | Multi-user, S3 storage, more sites, MCP access |
+
+Solo is the entry tier. Team is the upgrade path for collaboration.
+
+## Distribution
+
+1. Ship the MCP server.
+2. Announce on Twitter, Reddit (r/SelfHosted, r/programming), and Hacker News.
+3. List in MCP registries (Smithery, Anthropic directory).
+4. Publish a comparison post: "BareCMS vs Strapi for AI workflows."
+
+## Philosophy
+
+Bare minimal, on purpose.
+
+- One sentence describes the project: "MCP-native CMS."
+- Deploy with a single binary or Docker image.
+- Minimal surface, fast, no bloat.
+- Users own their content.
+
+Every feature decision passes through these.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,116 @@
+# BareCMS roadmap
+
+## Status
+
+What works today:
+
+- CRUD: sites, collections, entries
+- JWT authentication
+- PostgreSQL with GORM
+- Echo (Go) backend, React + TypeScript frontend
+- Docker and docker-compose
+- Public read API at `/api/:siteSlug/data`
+
+## Phase 1. Bare basics
+
+The basics every CMS needs. Without these, MCP positioning means nothing.
+
+- [ ] **Local file and image storage** (critical)
+  - Upload and serving endpoints
+  - Files table tracking size and MIME type
+  - Image picker in the collection editor
+  - `UPLOADS_DIR` and `MAX_FILE_SIZE` environment variables
+- [ ] **Input validation and structured error responses**
+  - Required, type, and length checks at the model layer
+  - Consistent error JSON shape
+  - Frontend renders field-level errors
+- [ ] **API stability**
+  - Lock response shapes for sites, collections, entries
+  - Pagination on list endpoints
+- [ ] **UI polish**
+  - Bug-free CRUD for every model
+  - Loading, empty, and error states
+  - Confirm dialogs on destructive actions
+- [ ] **Docker docs**
+  - Document every environment variable
+  - Provide `.env.production` example
+  - Add a `/healthz` endpoint
+  - Slim final image with multi-stage build
+
+## Phase 2. MCP-native pivot
+
+The differentiator.
+
+- [ ] **API tokens**
+  - Per-token revocation
+  - Scoped to a single site
+  - `Authorization: Bearer <token>` accepted by the existing API and MCP
+- [ ] **MCP server (HTTP transport)** exposing
+  - `list_sites`, `list_collections`, `list_entries`
+  - `get_entry`, `create_entry`, `update_entry`, `delete_entry`
+  - `query_entries` with filters and pagination
+  - `upload_file`
+- [ ] **Schema introspection endpoint**
+  - Lets agents discover collection fields without out-of-band setup
+- [ ] **Connect to Claude Desktop docs**
+  - Copy-paste config snippet
+  - Same setup for Cursor
+- [ ] **Submit to MCP registries** (Smithery, Anthropic directory)
+
+## Phase 3. SaaS MVP
+
+First paying customers.
+
+- [ ] **Multi-site per user**. One user owns multiple projects.
+- [ ] **Path-based multi-tenancy**. URLs look like `barecms.dev/u/<slug>`. No subdomain routing yet.
+- [ ] **Stripe Checkout**. Single $15 plan. Manual upgrade for team customers.
+- [ ] **Manual onboarding** for the first 30 customers. Instances created by hand.
+- [ ] **Daily DB backup script**. Cron plus S3 upload, kept simple.
+
+## Phase 4. Growth
+
+Only when paid users ask.
+
+- [ ] **External storage**. S3-compatible upload backend.
+- [ ] **Multi-user team tier**. Invitations, Admin and Editor roles, gated to the $30/mo plan.
+- [ ] **Subdomain routing and automated SSL**. Replaces path-based when it starts feeling limiting.
+- [ ] **One starter template**. A polished Astro example, not a marketplace.
+- [ ] **Automated provisioning**. Replaces manual onboarding once it becomes painful.
+
+## Out of scope
+
+The previous roadmap included these. They are removed.
+
+- Password reset flow (manual recovery for first 100 users)
+- Activity tracking and audit log
+- Webhooks (replaced by MCP server)
+- Granular permissions and custom roles
+- Template marketplace with multiple starters
+- Container orchestration (Docker Swarm, Kubernetes). Fly.io machines suffice.
+- Editor AI buttons. External agents handle this over MCP.
+
+## Pricing
+
+| Tier | Price | Includes |
+|---|---|---|
+| Self-hosted | Free | Full features, your infra, no support |
+| Solo (cloud) | $15/mo | 3 sites, local storage, single user, MCP access |
+| Team (cloud) | $30/mo | Multi-user, S3 storage, more sites, MCP access |
+
+## Success metrics
+
+- **Phase 1**. 10+ stars. First self-hoster reports a clean install.
+- **Phase 2**. Listed in MCP registries. First user reports editing via Claude.
+- **Phase 3**. First paying customer at $15 MRR.
+- **Phase 4**. $500+ MRR before adding team-tier features.
+
+## Philosophy
+
+Bare minimal, on purpose.
+
+- One sentence describes the project: "MCP-native CMS."
+- Deploy with a single binary or Docker image.
+- Minimal surface, fast, no bloat.
+- Users own their content.
+
+Every feature decision passes through these.


### PR DESCRIPTION
## Summary

- define BareCMS as a minimal MCP-native CMS
- organize delivery into fundamentals, MCP, SaaS, and growth phases
- document explicit non-goals, pricing, and success metrics

## Why

This gives implementation work a maintained, prioritized source of truth.