### PR TITLE
fix: enforce tenant authorization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/text v0.26.0
 	gorm.io/datatypes v1.2.1
 	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.5.6
 	gorm.io/gorm v1.25.11
 )
 
@@ -30,6 +31,7 @@ require (
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
@@ -48,5 +50,4 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.6 // indirect
-	gorm.io/driver/sqlite v1.5.6 // indirect
 )

--- a/internal/handlers/collections.go
+++ b/internal/handlers/collections.go
@@ -14,9 +14,9 @@ func (h *Handler) CreateCollection(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	err := h.Service.CreateCollection(req)
+	err := h.Service.CreateCollection(req, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusCreated, map[string]string{"message": "Collection created!"})
@@ -25,9 +25,9 @@ func (h *Handler) CreateCollection(c echo.Context) error {
 func (h *Handler) GetCollection(c echo.Context) error {
 	id := c.Param("id")
 
-	collection, err := h.Service.GetCollectionByID(id)
+	collection, err := h.Service.GetCollectionByID(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, collection)
@@ -36,9 +36,9 @@ func (h *Handler) GetCollection(c echo.Context) error {
 func (h *Handler) GetCollectionsBySiteID(c echo.Context) error {
 	siteID := c.Param("id")
 
-	collections, err := h.Service.GetCollectionsBySiteID(siteID)
+	collections, err := h.Service.GetCollectionsBySiteID(siteID, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{"collections": collections})
@@ -47,9 +47,9 @@ func (h *Handler) GetCollectionsBySiteID(c echo.Context) error {
 func (h *Handler) DeleteCollection(c echo.Context) error {
 	id := c.Param("id")
 
-	err := h.Service.DeleteCollection(id)
+	err := h.Service.DeleteCollection(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "Collection deleted!"})

--- a/internal/handlers/entries.go
+++ b/internal/handlers/entries.go
@@ -13,8 +13,8 @@ func (h *Handler) CreateEntry(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if err := h.Service.CreateEntry(&request); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	if err := h.Service.CreateEntry(&request, currentUserID(c)); err != nil {
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusCreated, map[string]string{"message": "Entry created!"})
@@ -23,9 +23,9 @@ func (h *Handler) CreateEntry(c echo.Context) error {
 func (h *Handler) GetEntry(c echo.Context) error {
 	id := c.Param("id")
 
-	entry, err := h.Service.GetEntryByID(id)
+	entry, err := h.Service.GetEntryByID(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, entry)
@@ -34,9 +34,9 @@ func (h *Handler) GetEntry(c echo.Context) error {
 func (h *Handler) GetCollectionEntries(c echo.Context) error {
 	id := c.Param("id")
 
-	entries, err := h.Service.GetEntriesByCollectionID(id)
+	entries, err := h.Service.GetEntriesByCollectionID(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, entries)
@@ -45,9 +45,9 @@ func (h *Handler) GetCollectionEntries(c echo.Context) error {
 func (h *Handler) DeleteEntry(c echo.Context) error {
 	id := c.Param("id")
 
-	err := h.Service.DeleteEntry(id)
+	err := h.Service.DeleteEntry(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "Entry deleted!"})

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,10 +3,23 @@ package handlers
 import (
 	"barecms/configs"
 	"barecms/internal/services"
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
+
+func currentUserID(c echo.Context) string {
+	userID, _ := c.Get("user_id").(string)
+	return userID
+}
+
+func serviceError(err error) error {
+	if errors.Is(err, services.ErrForbidden) {
+		return echo.NewHTTPError(http.StatusForbidden, err.Error())
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}
 
 type Handler struct {
 	Service *services.Service

--- a/internal/handlers/sites.go
+++ b/internal/handlers/sites.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *Handler) GetSites(c echo.Context) error {
-	sites, err := h.Service.GetSites()
+	sites, err := h.Service.GetSites(currentUserID(c))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -19,9 +19,9 @@ func (h *Handler) GetSites(c echo.Context) error {
 func (h *Handler) GetSite(c echo.Context) error {
 	id := c.Param("id")
 
-	site, err := h.Service.GetSite(id)
+	site, err := h.Service.GetSite(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, map[string]models.Site{"site": site})
@@ -30,9 +30,9 @@ func (h *Handler) GetSite(c echo.Context) error {
 func (h *Handler) GetSiteWithCollections(c echo.Context) error {
 	id := c.Param("id")
 
-	siteWithCollections, err := h.Service.GetSiteWithCollections(id)
+	siteWithCollections, err := h.Service.GetSiteWithCollections(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, siteWithCollections)
@@ -45,7 +45,7 @@ func (h *Handler) CreateSite(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	err := h.Service.CreateSite(req)
+	err := h.Service.CreateSite(req, currentUserID(c))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -55,9 +55,9 @@ func (h *Handler) CreateSite(c echo.Context) error {
 
 func (h *Handler) DeleteSite(c echo.Context) error {
 	id := c.Param("id")
-	err := h.Service.DeleteSite(id)
+	err := h.Service.DeleteSite(id, currentUserID(c))
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return serviceError(err)
 	}
 	return c.JSON(http.StatusOK, map[string]string{"message": "Site deleted!"})
 }

--- a/internal/services/authorization.go
+++ b/internal/services/authorization.go
@@ -1,0 +1,30 @@
+package services
+
+import "github.com/pkg/errors"
+
+var ErrForbidden = errors.New("you do not have access to this resource")
+
+func forbiddenUnless(allowed bool, err error) error {
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func (s *Service) requireSiteOwner(userID, siteID string) error {
+	allowed, err := s.Storage.UserOwnsSite(userID, siteID)
+	return forbiddenUnless(allowed, err)
+}
+
+func (s *Service) requireCollectionOwner(userID, collectionID string) error {
+	allowed, err := s.Storage.UserOwnsCollection(userID, collectionID)
+	return forbiddenUnless(allowed, err)
+}
+
+func (s *Service) requireEntryOwner(userID, entryID string) error {
+	allowed, err := s.Storage.UserOwnsEntry(userID, entryID)
+	return forbiddenUnless(allowed, err)
+}

--- a/internal/services/collections.go
+++ b/internal/services/collections.go
@@ -10,7 +10,10 @@ import (
 	"gorm.io/datatypes"
 )
 
-func (s *Service) CreateCollection(request models.CreateCollectionRequest) error {
+func (s *Service) CreateCollection(request models.CreateCollectionRequest, userID string) error {
+	if err := s.requireSiteOwner(userID, request.SiteID); err != nil {
+		return err
+	}
 
 	// Validate field types
 	for _, field := range request.Fields {
@@ -39,7 +42,10 @@ func (s *Service) CreateCollection(request models.CreateCollectionRequest) error
 	return nil
 }
 
-func (s *Service) GetCollectionByID(collectionID string) (models.Collection, error) {
+func (s *Service) GetCollectionByID(collectionID, userID string) (models.Collection, error) {
+	if err := s.requireCollectionOwner(userID, collectionID); err != nil {
+		return models.Collection{}, err
+	}
 	collectionDB, err := s.Storage.GetCollection(collectionID)
 	if err != nil {
 		return models.Collection{}, err
@@ -47,7 +53,10 @@ func (s *Service) GetCollectionByID(collectionID string) (models.Collection, err
 	return mapToCollection(collectionDB), nil
 }
 
-func (s *Service) GetCollectionsBySiteID(siteID string) ([]models.Collection, error) {
+func (s *Service) GetCollectionsBySiteID(siteID, userID string) ([]models.Collection, error) {
+	if err := s.requireSiteOwner(userID, siteID); err != nil {
+		return nil, err
+	}
 	collectionsDB, err := s.Storage.GetCollectionsBySiteID(siteID)
 	if err != nil {
 		return nil, err
@@ -60,7 +69,10 @@ func (s *Service) GetCollectionsBySiteID(siteID string) ([]models.Collection, er
 
 }
 
-func (s *Service) DeleteCollection(collectionID string) error {
+func (s *Service) DeleteCollection(collectionID, userID string) error {
+	if err := s.requireCollectionOwner(userID, collectionID); err != nil {
+		return err
+	}
 
 	if err := s.Storage.DeleteEntriesByCollectionID(collectionID); err != nil {
 		return err

--- a/internal/services/entries.go
+++ b/internal/services/entries.go
@@ -9,7 +9,10 @@ import (
 	"gorm.io/datatypes"
 )
 
-func (s *Service) CreateEntry(request *models.CreateEntryRequest) error {
+func (s *Service) CreateEntry(request *models.CreateEntryRequest, userID string) error {
+	if err := s.requireCollectionOwner(userID, request.CollectionID); err != nil {
+		return err
+	}
 	entry := models.Entry{
 		ID:           utils.GenerateUniqueID(),
 		CollectionID: request.CollectionID,
@@ -24,7 +27,10 @@ func (s *Service) CreateEntry(request *models.CreateEntryRequest) error {
 	return nil
 }
 
-func (s *Service) GetEntryByID(id string) (models.Entry, error) {
+func (s *Service) GetEntryByID(id, userID string) (models.Entry, error) {
+	if err := s.requireEntryOwner(userID, id); err != nil {
+		return models.Entry{}, err
+	}
 	entryDB, err := s.Storage.GetEntryByID(id)
 	if err != nil {
 		return models.Entry{}, err
@@ -32,7 +38,10 @@ func (s *Service) GetEntryByID(id string) (models.Entry, error) {
 	return mapToEntry(entryDB), nil
 }
 
-func (s *Service) GetEntriesByCollectionID(collectionID string) ([]models.Entry, error) {
+func (s *Service) GetEntriesByCollectionID(collectionID, userID string) ([]models.Entry, error) {
+	if err := s.requireCollectionOwner(userID, collectionID); err != nil {
+		return nil, err
+	}
 	entriesDB, err := s.Storage.GetEntriesByCollectionID(collectionID)
 	if err != nil {
 		return nil, err
@@ -44,7 +53,10 @@ func (s *Service) GetEntriesByCollectionID(collectionID string) ([]models.Entry,
 	return entries, nil
 }
 
-func (s *Service) DeleteEntry(id string) error {
+func (s *Service) DeleteEntry(id, userID string) error {
+	if err := s.requireEntryOwner(userID, id); err != nil {
+		return err
+	}
 	return s.Storage.DeleteEntry(id)
 }
 

--- a/internal/services/sites.go
+++ b/internal/services/sites.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 )
 
-func (s *Service) GetSites() ([]models.Site, error) {
-	sitesDB, err := s.Storage.GetSites()
+func (s *Service) GetSites(userID string) ([]models.Site, error) {
+	sitesDB, err := s.Storage.GetSitesByUserID(userID)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +23,10 @@ func (s *Service) GetSites() ([]models.Site, error) {
 	return sites, nil
 }
 
-func (s *Service) GetSite(id string) (models.Site, error) {
+func (s *Service) GetSite(id, userID string) (models.Site, error) {
+	if err := s.requireSiteOwner(userID, id); err != nil {
+		return models.Site{}, err
+	}
 	siteDB, err := s.Storage.GetSite(id)
 	if err != nil {
 		return models.Site{}, err
@@ -33,15 +36,15 @@ func (s *Service) GetSite(id string) (models.Site, error) {
 	return site, nil
 }
 
-func (s *Service) GetSiteWithCollections(id string) (map[string]interface{}, error) {
+func (s *Service) GetSiteWithCollections(id, userID string) (map[string]interface{}, error) {
 	// Get site
-	site, err := s.GetSite(id)
+	site, err := s.GetSite(id, userID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get collections for this site
-	collections, err := s.GetCollectionsBySiteID(id)
+	collections, err := s.GetCollectionsBySiteID(id, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -52,12 +55,12 @@ func (s *Service) GetSiteWithCollections(id string) (map[string]interface{}, err
 	}, nil
 }
 
-func (s *Service) CreateSite(request models.CreateSiteRequest) error {
+func (s *Service) CreateSite(request models.CreateSiteRequest, userID string) error {
 	newSite := models.Site{
 		ID:     utils.GenerateUniqueID(),
 		Name:   request.Name,
 		Slug:   utils.Slugify(request.Name),
-		UserID: request.UserID,
+		UserID: userID,
 	}
 	siteDB := mapToSiteDB(newSite)
 	if err := s.Storage.CreateSite(siteDB); err != nil {
@@ -67,7 +70,10 @@ func (s *Service) CreateSite(request models.CreateSiteRequest) error {
 	return nil
 }
 
-func (s *Service) DeleteSite(id string) error {
+func (s *Service) DeleteSite(id, userID string) error {
+	if err := s.requireSiteOwner(userID, id); err != nil {
+		return err
+	}
 
 	if err := s.Storage.DeleteSite(id); err != nil {
 		return err

--- a/internal/storage/authorization_test.go
+++ b/internal/storage/authorization_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func authorizationTestStorage(t *testing.T) *Storage {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+
+	return &Storage{DB: db}
+}
+
+func TestOwnershipFollowsResourceHierarchy(t *testing.T) {
+	storage := authorizationTestStorage(t)
+
+	if err := storage.DB.Create(&SiteDB{ID: "site-1", Name: "Site", Slug: "site", UserID: "owner-1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.DB.Create(&CollectionDB{ID: "collection-1", Name: "Posts", Slug: "posts", SiteID: "site-1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.DB.Create(&EntryDB{ID: "entry-1", CollectionID: "collection-1", Data: []byte(`{}`)}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		check func(string) (bool, error)
+	}{
+		{name: "site", check: func(userID string) (bool, error) { return storage.UserOwnsSite(userID, "site-1") }},
+		{name: "collection", check: func(userID string) (bool, error) { return storage.UserOwnsCollection(userID, "collection-1") }},
+		{name: "entry", check: func(userID string) (bool, error) { return storage.UserOwnsEntry(userID, "entry-1") }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			owned, err := test.check("owner-1")
+			if err != nil || !owned {
+				t.Fatalf("owner should have access: owned=%v err=%v", owned, err)
+			}
+
+			owned, err = test.check("another-user")
+			if err != nil {
+				t.Fatalf("check another user: %v", err)
+			}
+			if owned {
+				t.Fatal("another user must not have access")
+			}
+		})
+	}
+}

--- a/internal/storage/sites.go
+++ b/internal/storage/sites.go
@@ -51,6 +51,33 @@ func (s *Storage) GetSitesByUserID(userID string) ([]SiteDB, error) {
 	return sites, nil
 }
 
+func (s *Storage) UserOwnsSite(userID, siteID string) (bool, error) {
+	var count int64
+	err := s.DB.Model(&SiteDB{}).
+		Where("id = ? AND user_id = ?", siteID, userID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+func (s *Storage) UserOwnsCollection(userID, collectionID string) (bool, error) {
+	var count int64
+	err := s.DB.Table("collections").
+		Joins("JOIN sites ON sites.id = collections.site_id").
+		Where("collections.id = ? AND sites.user_id = ?", collectionID, userID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+func (s *Storage) UserOwnsEntry(userID, entryID string) (bool, error) {
+	var count int64
+	err := s.DB.Table("entries").
+		Joins("JOIN collections ON collections.id = entries.collection_id").
+		Joins("JOIN sites ON sites.id = collections.site_id").
+		Where("entries.id = ? AND sites.user_id = ?", entryID, userID).
+		Count(&count).Error
+	return count > 0, err
+}
+
 func (s *Storage) GetSiteBySlug(slug string) (SiteDB, error) {
 	var site SiteDB
 	retrieved := s.DB.Where("slug = ?", slug).First(&site)

--- a/roadmap.md
+++ b/roadmap.md
@@ -15,6 +15,16 @@ What works today:
 
 The basics every CMS needs. Without these, MCP positioning means nothing.
 
+### Security and tenant isolation
+
+- [x] **Tenant authorization implementation** (`security/tenant-authorization`)
+  - Scope site listings to the authenticated user
+  - Bind newly created sites to the JWT identity
+  - Enforce ownership through site, collection, and entry relationships
+- [x] Add cross-tenant authorization regression tests
+- [ ] Reject insecure default secrets in production
+- [ ] Add authentication rate limiting and request size limits
+
 - [ ] **Local file and image storage** (critical)
   - Upload and serving endpoints
   - Files table tracking size and MIME type


### PR DESCRIPTION
## Summary

- scope site listings to the authenticated user
- bind site creation to the JWT identity instead of request data
- enforce ownership across sites, collections, and entries
- return 403 for cross-tenant access attempts
- add hierarchy-based authorization regression tests
- update the live roadmap status

## Verification

- `go test ./internal/storage` passes
- `git diff --check` passes

## Worktree note

A full `go test ./...` run is currently blocked in the shared worktree by unrelated, uncommitted team-management code (`internal/models/site_user.go` defines methods on the built-in `string` type) and a missing generated `ui/dist`. Those files are not included in this PR.

## History

This replaces #17, which was accidentally merged into the already-merged roadmap branch instead of `main`.
