### PR TITLE
fix: harden production HTTP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ JWT_SECRET=your-super-secret-jwt-key
 # Server Configuration
 PORT=8080
 ENV=dev
+
+# Security limits
+# Echo body-size syntax: 1K, 2M, 1G
+MAX_REQUEST_BODY=2M
+# Shared per-IP limit across login and registration endpoints
+AUTH_RATE_LIMIT_PER_MINUTE=10

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,9 @@ func NewApp() *App {
 func (app *App) setup() {
 	slog.Info("Setting up the app")
 	cfg := configs.LoadAppConfig()
+	if err := cfg.Validate(); err != nil {
+		panic(fmt.Sprintf("Invalid configuration: %v", err))
+	}
 	svc := services.NewService(cfg)
 	r := router.Setup(svc, cfg)
 	app.router = r

--- a/configs/config.go
+++ b/configs/config.go
@@ -1,19 +1,25 @@
 package configs
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 )
 
 type AppConfig struct {
-	Env         string
-	Debug       bool
-	Port        int
-	DatabaseURL string
-	JWTSecret   string
+	Env                    string
+	Debug                  bool
+	Port                   int
+	DatabaseURL            string
+	JWTSecret              string
+	MaxRequestBody         string
+	AuthRateLimitPerMinute int
 }
+
+const DefaultJWTSecret = "your-secret-key-change-this-in-production"
 
 func LoadAppConfig() AppConfig {
 	viper.SetConfigFile(".env")
@@ -34,9 +40,29 @@ func LoadAppConfig() AppConfig {
 	cfg.Port = getEnvInt("PORT", 8080)
 	cfg.Debug = getEnvBool("DEBUG", true)
 	cfg.DatabaseURL = getEnvString("DATABASE_URL", "postgresql://barecms_user:basercms_password@postgres:5432/barecms")
-	cfg.JWTSecret = getEnvString("JWT_SECRET", "your-secret-key-change-this-in-production")
+	cfg.JWTSecret = getEnvString("JWT_SECRET", DefaultJWTSecret)
+	cfg.MaxRequestBody = getEnvString("MAX_REQUEST_BODY", "2M")
+	cfg.AuthRateLimitPerMinute = getEnvInt("AUTH_RATE_LIMIT_PER_MINUTE", 10)
 
 	return cfg
+}
+
+func (c AppConfig) Validate() error {
+	if c.AuthRateLimitPerMinute < 1 {
+		return fmt.Errorf("AUTH_RATE_LIMIT_PER_MINUTE must be at least 1")
+	}
+	if strings.TrimSpace(c.MaxRequestBody) == "" {
+		return fmt.Errorf("MAX_REQUEST_BODY cannot be empty")
+	}
+
+	env := strings.ToLower(strings.TrimSpace(c.Env))
+	if env == "prod" || env == "production" {
+		if c.JWTSecret == DefaultJWTSecret || len(c.JWTSecret) < 32 {
+			return fmt.Errorf("JWT_SECRET must be changed and contain at least 32 characters in production")
+		}
+	}
+
+	return nil
 }
 
 // Helper functions to get environment variables with fallbacks

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -1,0 +1,42 @@
+package configs
+
+import "testing"
+
+func TestValidateRejectsInsecureProductionSecret(t *testing.T) {
+	config := AppConfig{
+		Env:                    "production",
+		JWTSecret:              DefaultJWTSecret,
+		MaxRequestBody:         "2M",
+		AuthRateLimitPerMinute: 10,
+	}
+
+	if err := config.Validate(); err == nil {
+		t.Fatal("expected the default production JWT secret to be rejected")
+	}
+}
+
+func TestValidateAcceptsSecureProductionConfig(t *testing.T) {
+	config := AppConfig{
+		Env:                    "production",
+		JWTSecret:              "a-secure-secret-with-at-least-32-characters",
+		MaxRequestBody:         "2M",
+		AuthRateLimitPerMinute: 10,
+	}
+
+	if err := config.Validate(); err != nil {
+		t.Fatalf("expected valid production config: %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidLimits(t *testing.T) {
+	tests := []AppConfig{
+		{Env: "dev", MaxRequestBody: "", AuthRateLimitPerMinute: 10},
+		{Env: "dev", MaxRequestBody: "2M", AuthRateLimitPerMinute: 0},
+	}
+
+	for _, config := range tests {
+		if err := config.Validate(); err == nil {
+			t.Fatalf("expected invalid limits to be rejected: %+v", config)
+		}
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -6,13 +6,17 @@ import (
 	"barecms/internal/middlewares"
 	"barecms/internal/services"
 	"barecms/ui"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
 )
 
 func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	r := echo.New()
+	r.Use(middleware.BodyLimit(config.MaxRequestBody))
+	r.Use(middleware.SecureWithConfig(securityHeaders(config)))
 
 	if config.Env == "dev" {
 		r.Use(middleware.CORSWithConfig(middleware.CORSConfig{
@@ -36,8 +40,15 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	api.GET("/:siteSlug/data", h.GetSiteData)
 
 	// Auth routes (public)
-	api.POST("/auth/register", h.Register)
-	api.POST("/auth/login", h.Login)
+	authRateLimiter := middleware.RateLimiter(middleware.NewRateLimiterMemoryStoreWithConfig(
+		middleware.RateLimiterMemoryStoreConfig{
+			Rate:      rate.Limit(float64(config.AuthRateLimitPerMinute) / 60),
+			Burst:     config.AuthRateLimitPerMinute,
+			ExpiresIn: 5 * time.Minute,
+		},
+	))
+	api.POST("/auth/register", h.Register, authRateLimiter)
+	api.POST("/auth/login", h.Login, authRateLimiter)
 
 	// Protected routes
 	protected := api.Group("")
@@ -67,4 +78,15 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	protected.DELETE("/entries/:id", h.DeleteEntry)
 
 	return r
+}
+
+func securityHeaders(config configs.AppConfig) middleware.SecureConfig {
+	secure := middleware.DefaultSecureConfig
+	secure.XFrameOptions = "DENY"
+	secure.ContentTypeNosniff = "nosniff"
+	secure.ReferrerPolicy = "strict-origin-when-cross-origin"
+	if config.Env == "prod" || config.Env == "production" {
+		secure.HSTSMaxAge = 31536000
+	}
+	return secure
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,72 @@
+package router
+
+import (
+	"barecms/configs"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testConfig() configs.AppConfig {
+	return configs.AppConfig{
+		Env:                    "production",
+		JWTSecret:              "a-secure-secret-with-at-least-32-characters",
+		MaxRequestBody:         "16B",
+		AuthRateLimitPerMinute: 1,
+	}
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	router := Setup(nil, testConfig())
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	request.TLS = &tls.ConnectionState{}
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	if got := response.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("expected X-Frame-Options DENY, got %q", got)
+	}
+	if got := response.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected nosniff, got %q", got)
+	}
+	if got := response.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Fatal("expected HSTS in production")
+	}
+}
+
+func TestRequestBodyLimit(t *testing.T) {
+	router := Setup(nil, testConfig())
+	request := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"far-too-large@example.com"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", response.Code)
+	}
+}
+
+func TestAuthRateLimit(t *testing.T) {
+	config := testConfig()
+	config.MaxRequestBody = "2M"
+	router := Setup(nil, config)
+
+	first := httptest.NewRecorder()
+	router.ServeHTTP(first, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{`)))
+	if first.Code == http.StatusTooManyRequests {
+		t.Fatal("first auth request should not be rate limited")
+	}
+
+	second := httptest.NewRecorder()
+	router.ServeHTTP(second, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{`)))
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second auth request to return 429, got %d", second.Code)
+	}
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -22,8 +22,8 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - Bind newly created sites to the JWT identity
   - Enforce ownership through site, collection, and entry relationships
 - [x] Add cross-tenant authorization regression tests
-- [ ] Reject insecure default secrets in production
-- [ ] Add authentication rate limiting and request size limits
+- [x] Reject insecure default secrets in production (`security/config-hardening`)
+- [x] Add authentication rate limiting, request size limits, and security headers
 
 - [ ] **Local file and image storage** (critical)
   - Upload and serving endpoints


### PR DESCRIPTION
## Summary

- reject default or short JWT secrets in production
- add configurable global request-body limits
- rate-limit login and registration per client IP
- add clickjacking, MIME-sniffing, referrer, and production HSTS headers
- document new environment variables
- update the live roadmap

## Verification

- `npm run build`
- `go test ./...`
- `git diff --check`

## Tests added

- production configuration validation
- invalid security-limit validation
- HTTP security headers
- oversized request rejection
- authentication throttling
