### PR TITLE
feat: add secure local media storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ ENV=dev
 
 # Security limits
 # Echo body-size syntax: 1K, 2M, 1G
-MAX_REQUEST_BODY=2M
+# Keep this larger than MAX_FILE_SIZE to allow multipart overhead
+MAX_REQUEST_BODY=12M
 # Shared per-IP limit across login and registration endpoints
 AUTH_RATE_LIMIT_PER_MINUTE=10
+
+# Persistent media storage
+UPLOADS_DIR=/app/uploads
+# Maximum individual file size in bytes (10 MiB)
+MAX_FILE_SIZE=10485760

--- a/configs/config.go
+++ b/configs/config.go
@@ -17,6 +17,8 @@ type AppConfig struct {
 	JWTSecret              string
 	MaxRequestBody         string
 	AuthRateLimitPerMinute int
+	UploadsDir             string
+	MaxFileSize            int64
 }
 
 const DefaultJWTSecret = "your-secret-key-change-this-in-production"
@@ -41,8 +43,10 @@ func LoadAppConfig() AppConfig {
 	cfg.Debug = getEnvBool("DEBUG", true)
 	cfg.DatabaseURL = getEnvString("DATABASE_URL", "postgresql://barecms_user:basercms_password@postgres:5432/barecms")
 	cfg.JWTSecret = getEnvString("JWT_SECRET", DefaultJWTSecret)
-	cfg.MaxRequestBody = getEnvString("MAX_REQUEST_BODY", "2M")
+	cfg.MaxRequestBody = getEnvString("MAX_REQUEST_BODY", "12M")
 	cfg.AuthRateLimitPerMinute = getEnvInt("AUTH_RATE_LIMIT_PER_MINUTE", 10)
+	cfg.UploadsDir = getEnvString("UPLOADS_DIR", "uploads")
+	cfg.MaxFileSize = getEnvInt64("MAX_FILE_SIZE", 10*1024*1024)
 
 	return cfg
 }
@@ -54,6 +58,12 @@ func (c AppConfig) Validate() error {
 	if strings.TrimSpace(c.MaxRequestBody) == "" {
 		return fmt.Errorf("MAX_REQUEST_BODY cannot be empty")
 	}
+	if strings.TrimSpace(c.UploadsDir) == "" {
+		return fmt.Errorf("UPLOADS_DIR cannot be empty")
+	}
+	if c.MaxFileSize < 1 {
+		return fmt.Errorf("MAX_FILE_SIZE must be at least 1")
+	}
 
 	env := strings.ToLower(strings.TrimSpace(c.Env))
 	if env == "prod" || env == "production" {
@@ -63,6 +73,13 @@ func (c AppConfig) Validate() error {
 	}
 
 	return nil
+}
+
+func getEnvInt64(key string, fallback int64) int64 {
+	if viper.IsSet(key) {
+		return viper.GetInt64(key)
+	}
+	return fallback
 }
 
 // Helper functions to get environment variables with fallbacks

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -8,6 +8,8 @@ func TestValidateRejectsInsecureProductionSecret(t *testing.T) {
 		JWTSecret:              DefaultJWTSecret,
 		MaxRequestBody:         "2M",
 		AuthRateLimitPerMinute: 10,
+		UploadsDir:             "uploads",
+		MaxFileSize:            1024,
 	}
 
 	if err := config.Validate(); err == nil {
@@ -21,6 +23,8 @@ func TestValidateAcceptsSecureProductionConfig(t *testing.T) {
 		JWTSecret:              "a-secure-secret-with-at-least-32-characters",
 		MaxRequestBody:         "2M",
 		AuthRateLimitPerMinute: 10,
+		UploadsDir:             "uploads",
+		MaxFileSize:            1024,
 	}
 
 	if err := config.Validate(); err != nil {
@@ -30,8 +34,10 @@ func TestValidateAcceptsSecureProductionConfig(t *testing.T) {
 
 func TestValidateRejectsInvalidLimits(t *testing.T) {
 	tests := []AppConfig{
-		{Env: "dev", MaxRequestBody: "", AuthRateLimitPerMinute: 10},
-		{Env: "dev", MaxRequestBody: "2M", AuthRateLimitPerMinute: 0},
+		{Env: "dev", MaxRequestBody: "", AuthRateLimitPerMinute: 10, UploadsDir: "uploads", MaxFileSize: 1024},
+		{Env: "dev", MaxRequestBody: "2M", AuthRateLimitPerMinute: 0, UploadsDir: "uploads", MaxFileSize: 1024},
+		{Env: "dev", MaxRequestBody: "2M", AuthRateLimitPerMinute: 10, UploadsDir: "", MaxFileSize: 1024},
+		{Env: "dev", MaxRequestBody: "2M", AuthRateLimitPerMinute: 10, UploadsDir: "uploads", MaxFileSize: 0},
 	}
 
 	for _, config := range tests {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     ports:
       - "${PORT:-8080}:8080"
     env_file: .env
+    volumes:
+      - uploads_data:/app/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -23,3 +25,4 @@ services:
 
 volumes:
   postgres_data:
+  uploads_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     ports:
       - "${PORT:-8080}:8080"
     env_file: .env
+    volumes:
+      - uploads_data:/app/uploads
 
     depends_on:
       postgres:
@@ -27,3 +29,4 @@ services:
 
 volumes:
   postgres_data:
+  uploads_data:

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,6 +103,35 @@ This simple structure makes it easy to consume in frontend applications - you ca
 
 ---
 
+## Media files
+
+Uploaded media is owned by a site. Management endpoints require authentication
+and site ownership. JPEG, PNG, GIF, WebP, and PDF files are accepted.
+
+### Upload a file
+
+`POST /api/sites/:siteId/files` using a multipart form field named `file`.
+
+```bash
+curl -X POST http://localhost:8080/api/sites/site123/files \
+  -H "Authorization: Bearer <your-jwt-token>" \
+  -F "file=@image.png"
+```
+
+### List site files
+
+`GET /api/sites/:siteId/files`
+
+### Serve a file publicly
+
+`GET /api/files/:fileId`
+
+### Delete a file
+
+`DELETE /api/files/:fileId`
+
+Deleting a file requires authentication and ownership of its site.
+
 ## 🔐 Authentication Endpoints
 
 ### Register User

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -64,7 +64,17 @@ JWT_SECRET=your-super-secret-jwt-key-here
 
 # Application Configuration
 PORT=8080
+
+# Persistent uploads
+UPLOADS_DIR=/app/uploads
+MAX_FILE_SIZE=10485760
+# Must be larger than MAX_FILE_SIZE to allow multipart overhead
+MAX_REQUEST_BODY=12M
 ```
+
+The Compose configuration mounts `/app/uploads` in a named `uploads_data`
+volume. Back up this volume together with PostgreSQL; database-only backups do
+not contain uploaded media.
 
 💡 **Generate a secure JWT secret:**
 

--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"barecms/internal/services"
+	"errors"
+	"mime"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (h *Handler) UploadMedia(c echo.Context) error {
+	siteID := c.Param("siteId")
+	header, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "file form field is required")
+	}
+	source, err := header.Open()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "could not read uploaded file")
+	}
+	defer source.Close()
+
+	file, err := h.Service.UploadMedia(siteID, currentUserID(c), header.Filename, source)
+	if err != nil {
+		if errors.Is(err, services.ErrFileTooLarge) {
+			return echo.NewHTTPError(http.StatusRequestEntityTooLarge, err.Error())
+		}
+		if errors.Is(err, services.ErrUnsupportedFile) {
+			return echo.NewHTTPError(http.StatusUnsupportedMediaType, err.Error())
+		}
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusCreated, file)
+}
+
+func (h *Handler) ListMedia(c echo.Context) error {
+	files, err := h.Service.ListMedia(c.Param("siteId"), currentUserID(c))
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, map[string]any{"files": files})
+}
+
+func (h *Handler) GetMedia(c echo.Context) error {
+	file, path, err := h.Service.GetMedia(c.Param("fileId"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "file not found")
+	}
+	c.Response().Header().Set(echo.HeaderContentType, file.MIMEType)
+	c.Response().Header().Set(echo.HeaderContentDisposition, mime.FormatMediaType("inline", map[string]string{"filename": file.OriginalName}))
+	return c.File(path)
+}
+
+func (h *Handler) DeleteMedia(c echo.Context) error {
+	if err := h.Service.DeleteMedia(c.Param("fileId"), currentUserID(c)); err != nil {
+		return serviceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -19,7 +19,7 @@ func (h *Handler) UploadMedia(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "could not read uploaded file")
 	}
-	defer source.Close()
+	defer func() { _ = source.Close() }()
 
 	file, err := h.Service.UploadMedia(siteID, currentUserID(c), header.Filename, source)
 	if err != nil {

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+type MediaFile struct {
+	ID           string    `json:"id"`
+	SiteID       string    `json:"siteId"`
+	OriginalName string    `json:"originalName"`
+	MIMEType     string    `json:"mimeType"`
+	Size         int64     `json:"size"`
+	URL          string    `json:"url"`
+	CreatedAt    time.Time `json:"createdAt"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -38,6 +38,7 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 
 	// Public site data endpoint
 	api.GET("/:siteSlug/data", h.GetSiteData)
+	api.GET("/files/:fileId", h.GetMedia)
 
 	// Auth routes (public)
 	authRateLimiter := middleware.RateLimiter(middleware.NewRateLimiterMemoryStoreWithConfig(
@@ -64,6 +65,9 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	protected.GET("/sites/:id/collections", h.GetSiteWithCollections)
 	protected.POST("/sites", h.CreateSite)
 	protected.DELETE("/sites/:id", h.DeleteSite)
+	protected.GET("/sites/:siteId/files", h.ListMedia)
+	protected.POST("/sites/:siteId/files", h.UploadMedia)
+	protected.DELETE("/files/:fileId", h.DeleteMedia)
 
 	// Collections routes
 	protected.POST("/collections", h.CreateCollection)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -15,6 +15,8 @@ func testConfig() configs.AppConfig {
 		JWTSecret:              "a-secure-secret-with-at-least-32-characters",
 		MaxRequestBody:         "16B",
 		AuthRateLimitPerMinute: 1,
+		UploadsDir:             "uploads",
+		MaxFileSize:            1024,
 	}
 }
 

--- a/internal/services/media.go
+++ b/internal/services/media.go
@@ -1,0 +1,119 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"barecms/internal/storage"
+	"barecms/internal/utils"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+var (
+	ErrFileTooLarge    = errors.New("file is too large")
+	ErrUnsupportedFile = errors.New("unsupported file type")
+)
+
+var allowedMediaTypes = map[string]bool{
+	"image/jpeg":      true,
+	"image/png":       true,
+	"image/gif":       true,
+	"image/webp":      true,
+	"application/pdf": true,
+}
+
+func (s *Service) UploadMedia(siteID, userID, originalName string, source io.Reader) (models.MediaFile, error) {
+	if err := s.requireSiteOwner(userID, siteID); err != nil {
+		return models.MediaFile{}, err
+	}
+
+	contents, err := io.ReadAll(io.LimitReader(source, s.Config.MaxFileSize+1))
+	if err != nil {
+		return models.MediaFile{}, err
+	}
+	if int64(len(contents)) > s.Config.MaxFileSize {
+		return models.MediaFile{}, fmt.Errorf("%w: maximum is %d bytes", ErrFileTooLarge, s.Config.MaxFileSize)
+	}
+	if len(contents) == 0 {
+		return models.MediaFile{}, fmt.Errorf("file cannot be empty")
+	}
+
+	mimeType := http.DetectContentType(contents)
+	if !allowedMediaTypes[mimeType] {
+		return models.MediaFile{}, fmt.Errorf("%w: %s", ErrUnsupportedFile, mimeType)
+	}
+
+	id := utils.GenerateUniqueID()
+	extension := mediaExtension(mimeType)
+	storedName := id + extension
+	if err := os.MkdirAll(s.Config.UploadsDir, 0o750); err != nil {
+		return models.MediaFile{}, err
+	}
+	path := filepath.Join(s.Config.UploadsDir, storedName)
+	if err := os.WriteFile(path, contents, 0o640); err != nil {
+		return models.MediaFile{}, err
+	}
+
+	fileDB := storage.MediaFileDB{ID: id, SiteID: siteID, StoredName: storedName, OriginalName: filepath.Base(originalName), MIMEType: mimeType, Size: int64(len(contents))}
+	if err := s.Storage.CreateMediaFile(&fileDB); err != nil {
+		_ = os.Remove(path)
+		return models.MediaFile{}, err
+	}
+	return mapToMediaFile(fileDB), nil
+}
+
+func (s *Service) ListMedia(siteID, userID string) ([]models.MediaFile, error) {
+	if err := s.requireSiteOwner(userID, siteID); err != nil {
+		return nil, err
+	}
+	filesDB, err := s.Storage.GetMediaFilesBySiteID(siteID)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]models.MediaFile, len(filesDB))
+	for i, file := range filesDB {
+		files[i] = mapToMediaFile(file)
+	}
+	return files, nil
+}
+
+func (s *Service) GetMedia(id string) (models.MediaFile, string, error) {
+	file, err := s.Storage.GetMediaFile(id)
+	if err != nil {
+		return models.MediaFile{}, "", err
+	}
+	return mapToMediaFile(file), filepath.Join(s.Config.UploadsDir, file.StoredName), nil
+}
+
+func (s *Service) DeleteMedia(id, userID string) error {
+	file, err := s.Storage.GetMediaFile(id)
+	if err != nil {
+		return err
+	}
+	if err := s.requireSiteOwner(userID, file.SiteID); err != nil {
+		return err
+	}
+	if err := s.Storage.DeleteMediaFile(id); err != nil {
+		return err
+	}
+	if err := os.Remove(filepath.Join(s.Config.UploadsDir, file.StoredName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func mediaExtension(mimeType string) string {
+	extensions, _ := mime.ExtensionsByType(mimeType)
+	if len(extensions) > 0 {
+		return extensions[0]
+	}
+	return ""
+}
+
+func mapToMediaFile(file storage.MediaFileDB) models.MediaFile {
+	return models.MediaFile{ID: file.ID, SiteID: file.SiteID, OriginalName: file.OriginalName, MIMEType: file.MIMEType, Size: file.Size, URL: "/api/files/" + file.ID, CreatedAt: file.CreatedAt}
+}

--- a/internal/services/media_test.go
+++ b/internal/services/media_test.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"barecms/configs"
+	"barecms/internal/storage"
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func mediaTestService(t *testing.T) *Service {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&storage.SiteDB{}, &storage.MediaFileDB{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&storage.SiteDB{ID: "site-1", Name: "Site", Slug: "site", UserID: "owner-1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	return &Service{
+		Storage: &storage.Storage{DB: db},
+		Config:  configs.AppConfig{UploadsDir: t.TempDir(), MaxFileSize: 1024},
+	}
+}
+
+func pngBytes() []byte {
+	return append([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}, make([]byte, 504)...)
+}
+
+func TestMediaLifecycle(t *testing.T) {
+	service := mediaTestService(t)
+	file, err := service.UploadMedia("site-1", "owner-1", "../../logo.png", bytes.NewReader(pngBytes()))
+	if err != nil {
+		t.Fatalf("upload media: %v", err)
+	}
+	if file.OriginalName != "logo.png" || file.MIMEType != "image/png" {
+		t.Fatalf("unexpected metadata: %+v", file)
+	}
+
+	files, err := service.ListMedia("site-1", "owner-1")
+	if err != nil || len(files) != 1 {
+		t.Fatalf("list media: files=%d err=%v", len(files), err)
+	}
+	_, path, err := service.GetMedia(file.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stored file missing: %v", err)
+	}
+
+	if err := service.DeleteMedia(file.ID, "owner-1"); err != nil {
+		t.Fatalf("delete media: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected stored file deletion, got %v", err)
+	}
+}
+
+func TestMediaRejectsCrossTenantAndUnsafeUploads(t *testing.T) {
+	service := mediaTestService(t)
+	if _, err := service.UploadMedia("site-1", "another-user", "logo.png", bytes.NewReader(pngBytes())); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+	if _, err := service.UploadMedia("site-1", "owner-1", "script.html", bytes.NewReader([]byte("<script>alert(1)</script>"))); !errors.Is(err, ErrUnsupportedFile) {
+		t.Fatalf("expected unsupported file error, got %v", err)
+	}
+
+	service.Config.MaxFileSize = 4
+	if _, err := service.UploadMedia("site-1", "owner-1", "large.png", bytes.NewReader(pngBytes())); !errors.Is(err, ErrFileTooLarge) {
+		t.Fatalf("expected file-too-large error, got %v", err)
+	}
+}

--- a/internal/storage/media.go
+++ b/internal/storage/media.go
@@ -1,0 +1,21 @@
+package storage
+
+func (s *Storage) CreateMediaFile(file *MediaFileDB) error {
+	return s.DB.Create(file).Error
+}
+
+func (s *Storage) GetMediaFile(id string) (MediaFileDB, error) {
+	var file MediaFileDB
+	err := s.DB.Where("id = ?", id).First(&file).Error
+	return file, err
+}
+
+func (s *Storage) GetMediaFilesBySiteID(siteID string) ([]MediaFileDB, error) {
+	var files []MediaFileDB
+	err := s.DB.Where("site_id = ?", siteID).Order("created_at DESC").Find(&files).Error
+	return files, err
+}
+
+func (s *Storage) DeleteMediaFile(id string) error {
+	return s.DB.Where("id = ?", id).Delete(&MediaFileDB{}).Error
+}

--- a/internal/storage/schemas.go
+++ b/internal/storage/schemas.go
@@ -1,6 +1,10 @@
 package storage
 
-import "gorm.io/datatypes"
+import (
+	"time"
+
+	"gorm.io/datatypes"
+)
 
 type SiteDB struct {
 	ID     string `gorm:"primaryKey"`
@@ -42,6 +46,18 @@ type UserDB struct {
 	Username string `gorm:"uniqueIndex;not null"`
 	Password string `gorm:"not null"`
 }
+
+type MediaFileDB struct {
+	ID           string    `gorm:"primaryKey"`
+	SiteID       string    `gorm:"not null;index"`
+	StoredName   string    `gorm:"not null;uniqueIndex"`
+	OriginalName string    `gorm:"not null"`
+	MIMEType     string    `gorm:"not null"`
+	Size         int64     `gorm:"not null"`
+	CreatedAt    time.Time `gorm:"autoCreateTime"`
+}
+
+func (MediaFileDB) TableName() string { return "media_files" }
 
 func (UserDB) TableName() string {
 	return "users"

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -31,7 +31,7 @@ func openDatabase(url string) (*gorm.DB, error) {
 	}
 
 	// Migrate the schema
-	if err := database.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}, &UserDB{}); err != nil {
+	if err := database.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}, &UserDB{}, &MediaFileDB{}); err != nil {
 		return nil, errors.Wrap(err, "failed to migrate database schema")
 	}
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -26,10 +26,12 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [x] Add authentication rate limiting, request size limits, and security headers
 
 - [ ] **Local file and image storage** (critical)
-  - Upload and serving endpoints
-  - Files table tracking size and MIME type
+  - [x] Site-owned upload, serving, listing, and deletion endpoints (`feature/local-media-storage`)
+  - [x] Files table tracking size, MIME type, original name, and storage name
+  - [x] MIME allowlist, opaque filenames, size limits, and traversal protection
+  - [x] Persistent Docker upload volume
   - Image picker in the collection editor
-  - `UPLOADS_DIR` and `MAX_FILE_SIZE` environment variables
+  - [x] `UPLOADS_DIR` and `MAX_FILE_SIZE` environment variables
 - [ ] **Input validation and structured error responses**
   - Required, type, and length checks at the model layer
   - Consistent error JSON shape


### PR DESCRIPTION
## Summary

- add site-owned media metadata and persistence
- add authenticated upload, list, and delete endpoints
- add public serving by opaque file ID
- enforce file-size limits and a JPEG/PNG/GIF/WebP/PDF MIME allowlist
- generate storage names independently from user filenames
- persist uploads in Docker named volumes
- document configuration, backup requirements, and API usage
- update the live roadmap

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Security tests

- cross-tenant upload denial
- unsupported content rejection based on detected bytes
- oversized file rejection
- path traversal removal from original filenames
- stored-file deletion

## Follow-up

The collection editor image picker remains open as the final media milestone item.
