### PR TITLE
feat: add image picker to entry editor

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -25,12 +25,12 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [x] Reject insecure default secrets in production (`security/config-hardening`)
 - [x] Add authentication rate limiting, request size limits, and security headers
 
-- [ ] **Local file and image storage** (critical)
+- [x] **Local file and image storage** (critical)
   - [x] Site-owned upload, serving, listing, and deletion endpoints (`feature/local-media-storage`)
   - [x] Files table tracking size, MIME type, original name, and storage name
   - [x] MIME allowlist, opaque filenames, size limits, and traversal protection
   - [x] Persistent Docker upload volume
-  - Image picker in the collection editor
+  - [x] Image upload and existing-media picker in the collection editor (`feature/media-picker-ui`)
   - [x] `UPLOADS_DIR` and `MAX_FILE_SIZE` environment variables
 - [ ] **Input validation and structured error responses**
   - Required, type, and length checks at the model layer

--- a/ui/src/components/MediaPicker.tsx
+++ b/ui/src/components/MediaPicker.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useApi } from "@/hooks/useApi";
+import { MediaFile } from "@/types";
+
+interface MediaPickerProps {
+  siteId: string;
+  value: string;
+  onChange: (url: string) => void;
+  required?: boolean;
+}
+
+const MediaPicker: React.FC<MediaPickerProps> = ({
+  siteId,
+  value,
+  onChange,
+  required,
+}) => {
+  const [files, setFiles] = useState<MediaFile[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { request, loading } = useApi();
+
+  const loadFiles = useCallback(async () => {
+    try {
+      const response = await request({ url: `/sites/${siteId}/files` });
+      setFiles(
+        (response.files || []).filter((file: MediaFile) =>
+          file.mimeType.startsWith("image/"),
+        ),
+      );
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load media");
+    }
+  }, [request, siteId]);
+
+  useEffect(() => {
+    void loadFiles();
+  }, [loadFiles]);
+
+  const upload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0];
+    if (!selected) return;
+
+    const form = new FormData();
+    form.append("file", selected);
+    try {
+      const uploaded: MediaFile = await request({
+        url: `/sites/${siteId}/files`,
+        method: "POST",
+        data: form,
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setFiles((current) => [uploaded, ...current]);
+      onChange(uploaded.url);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        onChange={upload}
+        className="hidden"
+      />
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn btn-sm btn-primary"
+          disabled={loading}
+          onClick={() => inputRef.current?.click()}
+        >
+          {loading ? "Working..." : "Upload image"}
+        </button>
+        {value && (
+          <button type="button" className="btn btn-sm" onClick={() => onChange("")}>
+            Clear
+          </button>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-error">{error}</p>}
+      {value && (
+        <div className="flex items-center gap-3 rounded-bare border border-base-300 p-2">
+          <img src={value} alt="Selected media" className="h-16 w-16 rounded object-cover" />
+          <span className="min-w-0 truncate text-sm">Selected image</span>
+        </div>
+      )}
+
+      {files.length > 0 && (
+        <div>
+          <p className="mb-2 text-sm text-bare-600">Or choose an existing image</p>
+          <div className="grid max-h-48 grid-cols-3 gap-2 overflow-y-auto">
+            {files.map((file) => (
+              <button
+                type="button"
+                key={file.id}
+                title={file.originalName}
+                aria-label={`Select ${file.originalName}`}
+                onClick={() => onChange(file.url)}
+                className={`overflow-hidden rounded border-2 ${value === file.url ? "border-primary" : "border-transparent"}`}
+              >
+                <img src={file.url} alt={file.originalName} className="aspect-square w-full object-cover" />
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <input type="hidden" value={value} required={required} readOnly />
+    </div>
+  );
+};
+
+export default MediaPicker;

--- a/ui/src/components/modals/CreateEntryModal.tsx
+++ b/ui/src/components/modals/CreateEntryModal.tsx
@@ -1,15 +1,18 @@
 import { Field, FieldType } from "@/types/fields";
 import { useEffect, useState } from "react";
 import { useApi } from "@/hooks/useApi";
+import MediaPicker from "@/components/MediaPicker";
 
 interface CreateEntryModalProps {
   collectionId: string;
+  siteId: string;
   fields: Field[];
   dialogRef: React.RefObject<HTMLDialogElement>;
 }
 
 const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
   collectionId,
+  siteId,
   fields,
   dialogRef,
 }) => {
@@ -172,13 +175,12 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
         );
       case FieldType.IMAGE:
         return (
-          <input
-            type="url"
-            id={field.name}
-            name={field.name}
+          <MediaPicker
+            siteId={siteId}
             value={formState[field.name]}
-            onChange={handleInputChange}
-            className="input input-bordered w-full"
+            onChange={(url) =>
+              setFormState((previous) => ({ ...previous, [field.name]: url }))
+            }
             required={!field.optional}
           />
         );

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import apiClient from "@/lib/api";
 import { AxiosRequestConfig } from "axios";
 
@@ -6,7 +6,7 @@ export const useApi = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const request = async (config: AxiosRequestConfig) => {
+  const request = useCallback(async (config: AxiosRequestConfig) => {
     setLoading(true);
     setError(null);
 
@@ -21,7 +21,7 @@ export const useApi = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   return { request, loading, error };
 };

--- a/ui/src/pages/collections/Detail.tsx
+++ b/ui/src/pages/collections/Detail.tsx
@@ -198,6 +198,7 @@ const CollectionDetailsPage: React.FC = () => {
       <CreateEntryModal
         dialogRef={entryModalRef}
         collectionId={collection.id}
+        siteId={siteId as string}
         fields={collection.fields}
       />
     </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -37,3 +37,12 @@ export interface SiteData {
     data: any;
 }
 
+export interface MediaFile {
+    id: string;
+    siteId: string;
+    originalName: string;
+    mimeType: string;
+    size: number;
+    url: string;
+    createdAt: string;
+}


### PR DESCRIPTION
## Summary

- replace image URL-only fields with a site media picker
- upload JPEG, PNG, GIF, and WebP files directly from entry creation
- select and preview existing site images
- allow optional image values to be cleared
- stabilize the shared API request callback to avoid repeated fetch effects
- mark the Phase 1 media milestone complete

## Verification

- `npm run lint`
- `npm run build`
- `go test ./...`
- `git diff --check`
