### PR TITLE
feat: validate entries against collection schemas

### DIFF
--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func HTTPErrorHandler(err error, c echo.Context) {
+	if c.Response().Committed {
+		return
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		he = echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
+	}
+	if payload, ok := he.Message.(echo.Map); ok {
+		_ = c.JSON(he.Code, payload)
+		return
+	}
+	_ = c.JSON(he.Code, echo.Map{"error": echo.Map{"code": http.StatusText(he.Code), "message": he.Message}})
+}

--- a/internal/handlers/errors_test.go
+++ b/internal/handlers/errors_test.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestHTTPErrorHandlerPreservesStructuredPayload(t *testing.T) {
+	e := echo.New()
+	e.HTTPErrorHandler = HTTPErrorHandler
+	e.GET("/", func(echo.Context) error {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, echo.Map{"error": echo.Map{"code": "validation_failed"}})
+	})
+	response := httptest.NewRecorder()
+	e.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	var body map[string]map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"]["code"] != "validation_failed" {
+		t.Fatalf("unexpected error response: %s", response.Body.String())
+	}
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -15,6 +15,13 @@ func currentUserID(c echo.Context) string {
 }
 
 func serviceError(err error) error {
+	var validationError *services.ValidationError
+	if errors.As(err, &validationError) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, echo.Map{"error": echo.Map{
+			"code": "validation_failed", "message": validationError.Error(), "fields": validationError.Fields,
+		},
+		})
+	}
 	if errors.Is(err, services.ErrForbidden) {
 		return echo.NewHTTPError(http.StatusForbidden, err.Error())
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,6 +15,7 @@ import (
 
 func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	r := echo.New()
+	r.HTTPErrorHandler = handlers.HTTPErrorHandler
 	r.Use(middleware.BodyLimit(config.MaxRequestBody))
 	r.Use(middleware.SecureWithConfig(securityHeaders(config)))
 

--- a/internal/services/entries.go
+++ b/internal/services/entries.go
@@ -13,6 +13,14 @@ func (s *Service) CreateEntry(request *models.CreateEntryRequest, userID string)
 	if err := s.requireCollectionOwner(userID, request.CollectionID); err != nil {
 		return err
 	}
+	collectionDB, err := s.Storage.GetCollection(request.CollectionID)
+	if err != nil {
+		return err
+	}
+	collection := mapToCollection(collectionDB)
+	if err := validateEntryData(request.Data, collection.Fields); err != nil {
+		return err
+	}
 	entry := models.Entry{
 		ID:           utils.GenerateUniqueID(),
 		CollectionID: request.CollectionID,

--- a/internal/services/validation.go
+++ b/internal/services/validation.go
@@ -1,0 +1,83 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type ValidationError struct {
+	Fields map[string]string
+}
+
+func (e *ValidationError) Error() string { return "entry validation failed" }
+
+type entryFieldValue struct {
+	Value any              `json:"value"`
+	Type  models.FieldType `json:"type"`
+}
+
+func validateEntryData(data json.RawMessage, fields []models.Field) error {
+	var values map[string]entryFieldValue
+	if err := json.Unmarshal(data, &values); err != nil {
+		return &ValidationError{Fields: map[string]string{"data": "must be a JSON object"}}
+	}
+	errors := make(map[string]string)
+	schema := make(map[string]models.Field, len(fields))
+	for _, field := range fields {
+		schema[field.Name] = field
+		value, exists := values[field.Name]
+		if !exists || value.Value == nil || fmt.Sprint(value.Value) == "" {
+			if !field.Optional {
+				errors[field.Name] = "is required"
+			}
+			continue
+		}
+		if value.Type != field.Type {
+			errors[field.Name] = "type does not match collection schema"
+			continue
+		}
+		if message := validateFieldValue(field.Type, value.Value); message != "" {
+			errors[field.Name] = message
+		}
+	}
+	for name := range values {
+		if _, exists := schema[name]; !exists {
+			errors[name] = "is not defined in the collection schema"
+		}
+	}
+	if len(errors) > 0 {
+		return &ValidationError{Fields: errors}
+	}
+	return nil
+}
+
+func validateFieldValue(fieldType models.FieldType, value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return "must be a string value"
+	}
+	switch fieldType {
+	case models.FieldTypeNumber:
+		if _, err := strconv.ParseFloat(text, 64); err != nil {
+			return "must be a number"
+		}
+	case models.FieldTypeBoolean:
+		if _, err := strconv.ParseBool(text); err != nil {
+			return "must be true or false"
+		}
+	case models.FieldTypeDate:
+		if _, err := time.Parse("2006-01-02", text); err != nil {
+			return "must use YYYY-MM-DD format"
+		}
+	case models.FieldTypeURL, models.FieldTypeImage:
+		parsed, err := url.ParseRequestURI(text)
+		if err != nil || (parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return "must be a valid URL"
+		}
+	}
+	return ""
+}

--- a/internal/services/validation_test.go
+++ b/internal/services/validation_test.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestValidateEntryData(t *testing.T) {
+	fields := []models.Field{
+		{Name: "title", Type: models.FieldTypeString},
+		{Name: "rating", Type: models.FieldTypeNumber},
+		{Name: "published", Type: models.FieldTypeBoolean},
+		{Name: "date", Type: models.FieldTypeDate},
+		{Name: "image", Type: models.FieldTypeImage, Optional: true},
+	}
+	valid := json.RawMessage(`{"title":{"value":"Post","type":"string"},"rating":{"value":"4.5","type":"number"},"published":{"value":"true","type":"boolean"},"date":{"value":"2026-07-12","type":"date"},"image":{"value":null,"type":"image"}}`)
+	if err := validateEntryData(valid, fields); err != nil {
+		t.Fatalf("valid entry rejected: %v", err)
+	}
+
+	invalid := json.RawMessage(`{"rating":{"value":"many","type":"number"},"published":{"value":"yes","type":"boolean"},"date":{"value":"tomorrow","type":"date"},"extra":{"value":"x","type":"string"}}`)
+	err := validateEntryData(invalid, fields)
+	var validationError *ValidationError
+	if !errors.As(err, &validationError) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	for _, field := range []string{"title", "rating", "published", "date", "extra"} {
+		if validationError.Fields[field] == "" {
+			t.Errorf("expected error for %s", field)
+		}
+	}
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -33,8 +33,9 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - [x] Image upload and existing-media picker in the collection editor (`feature/media-picker-ui`)
   - [x] `UPLOADS_DIR` and `MAX_FILE_SIZE` environment variables
 - [ ] **Input validation and structured error responses**
-  - Required, type, and length checks at the model layer
-  - Consistent error JSON shape
+  - [x] Required, schema, primitive type, URL, and date checks for entries (`feature/entry-validation`)
+  - [x] Field-level `422 validation_failed` response shape
+  - [ ] Length and numeric range constraints in collection schemas
   - Frontend renders field-level errors
 - [ ] **API stability**
   - Lock response shapes for sites, collections, entries

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -14,8 +14,11 @@ export const useApi = () => {
       const response = await apiClient(config);
       return response.data;
     } catch (err: any) {
+      const apiError = err.response?.data?.error;
       const errorMessage =
-        err.response?.data?.error || err.response?.data?.message || err.message;
+        (typeof apiError === "string" ? apiError : apiError?.message) ||
+        err.response?.data?.message ||
+        err.message;
       setError(errorMessage);
       throw new Error(errorMessage);
     } finally {


### PR DESCRIPTION
## Summary

- validate entry payloads against collection schemas before persistence
- reject missing required fields, unknown fields, and schema type mismatches
- validate numeric, boolean, date, URL, and image values
- return field-level HTTP 422 errors in a stable error envelope
- keep the UI API client compatible with structured errors
- avoid redundant collection ownership lookups during creation
- update the live roadmap

## Verification

- `npm run lint`
- `npm run build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
