### PR TITLE
feat: add validated entry editing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -132,6 +132,12 @@ curl -X POST http://localhost:8080/api/sites/site123/files \
 
 Deleting a file requires authentication and ownership of its site.
 
+### Update an entry
+
+`PUT /api/entries/:entryId` accepts a `data` object in the same typed field
+format as entry creation. The complete payload is validated against the
+collection schema before it replaces the existing entry data.
+
 ## 🔐 Authentication Endpoints
 
 ### Register User

--- a/internal/handlers/entries.go
+++ b/internal/handlers/entries.go
@@ -52,3 +52,15 @@ func (h *Handler) DeleteEntry(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "Entry deleted!"})
 }
+
+func (h *Handler) UpdateEntry(c echo.Context) error {
+	var request models.UpdateEntryRequest
+	if err := c.Bind(&request); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	entry, err := h.Service.UpdateEntry(c.Param("id"), currentUserID(c), request)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, entry)
+}

--- a/internal/models/entry.go
+++ b/internal/models/entry.go
@@ -12,3 +12,7 @@ type CreateEntryRequest struct {
 	CollectionID string          `json:"collectionId"`
 	Data         json.RawMessage `json:"data"`
 }
+
+type UpdateEntryRequest struct {
+	Data json.RawMessage `json:"data"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -80,6 +80,7 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	// Entries routes
 	protected.POST("/entries", h.CreateEntry)
 	protected.GET("/entries/:id", h.GetEntry)
+	protected.PUT("/entries/:id", h.UpdateEntry)
 	protected.DELETE("/entries/:id", h.DeleteEntry)
 
 	return r

--- a/internal/services/entries.go
+++ b/internal/services/entries.go
@@ -68,6 +68,28 @@ func (s *Service) DeleteEntry(id, userID string) error {
 	return s.Storage.DeleteEntry(id)
 }
 
+func (s *Service) UpdateEntry(id, userID string, request models.UpdateEntryRequest) (models.Entry, error) {
+	if err := s.requireEntryOwner(userID, id); err != nil {
+		return models.Entry{}, err
+	}
+	entryDB, err := s.Storage.GetEntryByID(id)
+	if err != nil {
+		return models.Entry{}, err
+	}
+	collectionDB, err := s.Storage.GetCollection(entryDB.CollectionID)
+	if err != nil {
+		return models.Entry{}, err
+	}
+	if err := validateEntryData(request.Data, mapToCollection(collectionDB).Fields); err != nil {
+		return models.Entry{}, err
+	}
+	if err := s.Storage.UpdateEntryData(id, request.Data); err != nil {
+		return models.Entry{}, err
+	}
+	entryDB.Data = datatypes.JSON(request.Data)
+	return mapToEntry(entryDB), nil
+}
+
 func mapToEntryDB(entry models.Entry) storage.EntryDB {
 	return storage.EntryDB{
 		ID:           entry.ID,

--- a/internal/services/entries_test.go
+++ b/internal/services/entries_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"barecms/internal/storage"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func entryTestService(t *testing.T) *Service {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&storage.SiteDB{}, &storage.CollectionDB{}, &storage.EntryDB{}); err != nil {
+		t.Fatal(err)
+	}
+	fields, _ := json.Marshal([]models.Field{{Name: "title", Type: models.FieldTypeString}})
+	for _, record := range []any{
+		&storage.SiteDB{ID: "site-1", Name: "Site", Slug: "site", UserID: "owner-1"},
+		&storage.CollectionDB{ID: "collection-1", SiteID: "site-1", Name: "Posts", Slug: "posts", Fields: datatypes.JSON(fields)},
+		&storage.EntryDB{ID: "entry-1", CollectionID: "collection-1", Data: datatypes.JSON(`{"title":{"value":"Old","type":"string"}}`)},
+	} {
+		if err := db.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Service{Storage: &storage.Storage{DB: db}}
+}
+
+func TestUpdateEntryValidatesOwnershipAndSchema(t *testing.T) {
+	service := entryTestService(t)
+	valid := models.UpdateEntryRequest{Data: json.RawMessage(`{"title":{"value":"New","type":"string"}}`)}
+	if _, err := service.UpdateEntry("entry-1", "another-user", valid); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+	invalid := models.UpdateEntryRequest{Data: json.RawMessage(`{"title":{"value":"","type":"string"}}`)}
+	if _, err := service.UpdateEntry("entry-1", "owner-1", invalid); err == nil {
+		t.Fatal("expected validation error")
+	}
+	updated, err := service.UpdateEntry("entry-1", "owner-1", valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(updated.Data) != string(valid.Data) {
+		t.Fatalf("unexpected data: %s", updated.Data)
+	}
+}

--- a/internal/storage/entries.go
+++ b/internal/storage/entries.go
@@ -26,6 +26,10 @@ func (s *Storage) GetEntriesByCollectionID(collectionID string) ([]EntryDB, erro
 	return entries, nil
 }
 
+func (s *Storage) UpdateEntryData(id string, data []byte) error {
+	return s.DB.Model(&EntryDB{}).Where("id = ?", id).Update("data", data).Error
+}
+
 func (s *Storage) DeleteEntry(id string) error {
 	deleted := s.DB.Where("id = ?", id).Delete(&EntryDB{})
 	if deleted.Error != nil {

--- a/roadmap.md
+++ b/roadmap.md
@@ -15,6 +15,10 @@ What works today:
 
 The basics every CMS needs. Without these, MCP positioning means nothing.
 
+- [x] **Entry editing workflow** (`feature/content-updates`)
+  - Tenant-safe update endpoint with schema validation
+  - Editor UI reusing typed controls and the media picker
+
 ### Security and tenant isolation
 
 - [x] **Tenant authorization implementation** (`security/tenant-authorization`)

--- a/ui/src/components/cards/EntryCard.tsx
+++ b/ui/src/components/cards/EntryCard.tsx
@@ -1,8 +1,9 @@
 import useDelete from "@/hooks/useDelete";
-import { Trash2 } from "lucide-react";
+import { Pencil, Trash2 } from "lucide-react";
 import Loader from "@/components/Loader";
-import React from "react";
-import { FieldType } from "@/types/fields";
+import React, { useRef } from "react";
+import { Field, FieldType } from "@/types/fields";
+import CreateEntryModal from "@/components/modals/CreateEntryModal";
 
 interface EntryData {
   value: any;
@@ -14,6 +15,7 @@ interface EntryCardProps {
   collectionId: string;
   entryId: string;
   data: Record<string, EntryData>;
+  fields: Field[];
 }
 
 const EntryCard: React.FC<EntryCardProps> = ({
@@ -21,7 +23,9 @@ const EntryCard: React.FC<EntryCardProps> = ({
   siteId,
   entryId,
   data,
+  fields,
 }) => {
+	const editModalRef = useRef<HTMLDialogElement>(null);
   const { isDeleting, error, handleDelete } = useDelete(
     `/entries/${entryId}`,
     `/sites/${siteId}/collections/${collectionId}`,
@@ -104,7 +108,14 @@ const EntryCard: React.FC<EntryCardProps> = ({
         ))}
       </div>
 
-      <div className="flex justify-end border-t border-bare-200 pt-3 mt-3">
+      <div className="flex justify-end gap-1 border-t border-bare-200 pt-3 mt-3">
+        <button
+          onClick={() => editModalRef.current?.showModal()}
+          className="p-2 text-bare-400 hover:text-primary transition-colors rounded"
+          aria-label="Edit entry"
+        >
+          <Pencil size={16} />
+        </button>
         <button
           onClick={handleDelete}
           className="p-2 text-bare-400 hover:text-error transition-colors rounded"
@@ -113,6 +124,14 @@ const EntryCard: React.FC<EntryCardProps> = ({
           <Trash2 size={16} />
         </button>
       </div>
+      <CreateEntryModal
+        dialogRef={editModalRef}
+        collectionId={collectionId}
+        siteId={siteId}
+        fields={fields}
+        entryId={entryId}
+        initialData={data}
+      />
     </div>
   );
 };

--- a/ui/src/components/modals/CreateEntryModal.tsx
+++ b/ui/src/components/modals/CreateEntryModal.tsx
@@ -8,6 +8,8 @@ interface CreateEntryModalProps {
   siteId: string;
   fields: Field[];
   dialogRef: React.RefObject<HTMLDialogElement>;
+  entryId?: string;
+  initialData?: Record<string, { value: any; type: string }>;
 }
 
 const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
@@ -15,6 +17,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
   siteId,
   fields,
   dialogRef,
+  entryId,
+  initialData,
 }) => {
   const [formState, setFormState] = useState<Record<string, any>>({});
   const [error, setError] = useState<string | null>(null);
@@ -31,13 +35,13 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
     const initialFormState: Record<string, any> = {};
     fields.forEach((field) => {
       if (field.type === FieldType.BOOLEAN) {
-        initialFormState[field.name] = "false";
+        initialFormState[field.name] = initialData?.[field.name]?.value ?? "false";
       } else {
-        initialFormState[field.name] = "";
+        initialFormState[field.name] = initialData?.[field.name]?.value ?? "";
       }
     });
     setFormState(initialFormState);
-  }, [fields]);
+  }, [fields, initialData]);
 
   const handleInputChange = (
     e: React.ChangeEvent<
@@ -49,13 +53,9 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
   };
 
   const handleSubmit = async () => {
-    console.log("fields", fields);
-
     const hasRequiredFields = fields.some(
       (field) => !field.optional && formState[field.name].trim() === "",
     );
-
-    console.log("hasEmptyFields", hasRequiredFields);
 
     if (hasRequiredFields) {
       setError("All fields are required.");
@@ -67,8 +67,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
       // Prepare data with types
       const dataWithTypes = fields.reduce(
         (acc, field) => {
-          let value = formState[field.name]
-          if (field.optional && value.trim() === "") value = null
+          let value = formState[field.name];
+          if (field.optional && value.trim() === "") value = null;
           acc[field.name] = {
             value,
             type: field.type,
@@ -79,12 +79,11 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
       );
 
       await request({
-        url: "/entries",
-        method: "POST",
-        data: { collectionId, data: dataWithTypes },
+        url: entryId ? `/entries/${entryId}` : "/entries",
+        method: entryId ? "PUT" : "POST",
+        data: entryId ? { data: dataWithTypes } : { collectionId, data: dataWithTypes },
       });
 
-      console.log("Entry created successfully");
       closeDialog();
       setTimeout(() => {
         window.location.reload();
@@ -154,7 +153,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             className="select select-bordered w-full"
             required={!field.optional}
           >
-            <option disabled selected>
+            <option disabled>
               Select an option
             </option>
             <option value="true">True</option>
@@ -202,7 +201,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
   return (
     <dialog className="modal" ref={dialogRef}>
       <div className="modal-box">
-        <h3 className="font-bold text-lg mb-3">Create new entry</h3>
+        <h3 className="font-bold text-lg mb-3">{entryId ? "Edit entry" : "Create new entry"}</h3>
         {error && <p className="text-red-500 mb-4">{error}</p>}
         <div className="mt-4">
           {fields.map((field) => (
@@ -223,7 +222,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onClick={handleSubmit}
             className="btn btn-primary"
           >
-            {loading ? "Creating..." : "Create"}
+            {loading ? "Saving..." : entryId ? "Save changes" : "Create"}
           </button>
           <button className="btn" onClick={closeDialog}>
             Cancel

--- a/ui/src/pages/collections/Detail.tsx
+++ b/ui/src/pages/collections/Detail.tsx
@@ -172,6 +172,7 @@ const CollectionDetailsPage: React.FC = () => {
                 collectionId={collection.id}
                 entryId={entry.id}
                 data={entry.data}
+                fields={collection.fields}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary

- add a tenant-safe PUT endpoint for entry updates
- validate replacement data against the collection schema
- add cross-tenant, invalid-schema, and successful-update regression coverage
- add an edit action to entry cards
- reuse the typed entry form and media picker for editing
- remove editor debug logging and update API docs and roadmap

## Verification

- `npm run lint`
- `npm run build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
