### PR TITLE
feat: paginate collection entries

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -138,6 +138,19 @@ Deleting a file requires authentication and ownership of its site.
 format as entry creation. The complete payload is validated against the
 collection schema before it replaces the existing entry data.
 
+### List collection entries
+
+`GET /api/collections/:collectionId/entries?page=1&limit=20` returns:
+
+```json
+{
+  "entries": [],
+  "pagination": { "page": 1, "limit": 20, "total": 0, "totalPages": 0 }
+}
+```
+
+`page` starts at 1 and `limit` is capped at 100.
+
 ## 🔐 Authentication Endpoints
 
 ### Register User

--- a/internal/handlers/entries.go
+++ b/internal/handlers/entries.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"barecms/internal/models"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -33,13 +35,35 @@ func (h *Handler) GetEntry(c echo.Context) error {
 
 func (h *Handler) GetCollectionEntries(c echo.Context) error {
 	id := c.Param("id")
+	page, err := paginationParameter("page", c.QueryParam("page"), 1, 1, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	limit, err := paginationParameter("limit", c.QueryParam("limit"), 20, 1, 100)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
 
-	entries, err := h.Service.GetEntriesByCollectionID(id, currentUserID(c))
+	entries, err := h.Service.GetEntriesPage(id, currentUserID(c), page, limit)
 	if err != nil {
 		return serviceError(err)
 	}
 
 	return c.JSON(http.StatusOK, entries)
+}
+
+func paginationParameter(name, raw string, fallback, minimum, maximum int) (int, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minimum || (maximum > 0 && value > maximum) {
+		if maximum == 0 {
+			return 0, fmt.Errorf("%s must be an integer of at least %d", name, minimum)
+		}
+		return 0, fmt.Errorf("%s must be an integer between %d and %d", name, minimum, maximum)
+	}
+	return value, nil
 }
 
 func (h *Handler) DeleteEntry(c echo.Context) error {

--- a/internal/handlers/entries_test.go
+++ b/internal/handlers/entries_test.go
@@ -1,0 +1,14 @@
+package handlers
+
+import "testing"
+
+func TestPaginationParameterBounds(t *testing.T) {
+	if value, err := paginationParameter("limit", "", 20, 1, 100); err != nil || value != 20 {
+		t.Fatalf("unexpected default: %d %v", value, err)
+	}
+	for _, raw := range []string{"0", "101", "nope"} {
+		if _, err := paginationParameter("limit", raw, 20, 1, 100); err == nil {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
+	}
+}

--- a/internal/models/entry.go
+++ b/internal/models/entry.go
@@ -16,3 +16,15 @@ type CreateEntryRequest struct {
 type UpdateEntryRequest struct {
 	Data json.RawMessage `json:"data"`
 }
+
+type Pagination struct {
+	Page       int   `json:"page"`
+	Limit      int   `json:"limit"`
+	Total      int64 `json:"total"`
+	TotalPages int   `json:"totalPages"`
+}
+
+type EntryPage struct {
+	Entries    []Entry    `json:"entries"`
+	Pagination Pagination `json:"pagination"`
+}

--- a/internal/services/entries.go
+++ b/internal/services/entries.go
@@ -61,6 +61,22 @@ func (s *Service) GetEntriesByCollectionID(collectionID, userID string) ([]model
 	return entries, nil
 }
 
+func (s *Service) GetEntriesPage(collectionID, userID string, page, limit int) (models.EntryPage, error) {
+	if err := s.requireCollectionOwner(userID, collectionID); err != nil {
+		return models.EntryPage{}, err
+	}
+	entriesDB, total, err := s.Storage.GetEntriesPage(collectionID, limit, (page-1)*limit)
+	if err != nil {
+		return models.EntryPage{}, err
+	}
+	entries := make([]models.Entry, len(entriesDB))
+	for i, entryDB := range entriesDB {
+		entries[i] = mapToEntry(entryDB)
+	}
+	totalPages := int((total + int64(limit) - 1) / int64(limit))
+	return models.EntryPage{Entries: entries, Pagination: models.Pagination{Page: page, Limit: limit, Total: total, TotalPages: totalPages}}, nil
+}
+
 func (s *Service) DeleteEntry(id, userID string) error {
 	if err := s.requireEntryOwner(userID, id); err != nil {
 		return err

--- a/internal/services/entries_test.go
+++ b/internal/services/entries_test.go
@@ -52,3 +52,19 @@ func TestUpdateEntryValidatesOwnershipAndSchema(t *testing.T) {
 		t.Fatalf("unexpected data: %s", updated.Data)
 	}
 }
+
+func TestGetEntriesPageReturnsBoundedMetadata(t *testing.T) {
+	service := entryTestService(t)
+	for _, id := range []string{"entry-2", "entry-3", "entry-4"} {
+		if err := service.Storage.CreateEntry(storage.EntryDB{ID: id, CollectionID: "collection-1", Data: datatypes.JSON(`{"title":{"value":"Post","type":"string"}}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := service.GetEntriesPage("collection-1", "owner-1", 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Entries) != 2 || result.Pagination.Total != 4 || result.Pagination.TotalPages != 2 || result.Pagination.Page != 2 {
+		t.Fatalf("unexpected page: %+v", result)
+	}
+}

--- a/internal/storage/entries.go
+++ b/internal/storage/entries.go
@@ -26,6 +26,17 @@ func (s *Storage) GetEntriesByCollectionID(collectionID string) ([]EntryDB, erro
 	return entries, nil
 }
 
+func (s *Storage) GetEntriesPage(collectionID string, limit, offset int) ([]EntryDB, int64, error) {
+	var total int64
+	if err := s.DB.Model(&EntryDB{}).Where("collection_id = ?", collectionID).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var entries []EntryDB
+	err := s.DB.Where("collection_id = ?", collectionID).
+		Order("id ASC").Limit(limit).Offset(offset).Find(&entries).Error
+	return entries, total, err
+}
+
 func (s *Storage) UpdateEntryData(id string, data []byte) error {
 	return s.DB.Model(&EntryDB{}).Where("id = ?", id).Update("data", data).Error
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -43,7 +43,8 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - Frontend renders field-level errors
 - [ ] **API stability**
   - Lock response shapes for sites, collections, entries
-  - Pagination on list endpoints
+  - [x] Bounded pagination and metadata for collection entries (`feature/api-pagination`)
+  - [ ] Pagination on remaining authenticated list endpoints
 - [ ] **UI polish**
   - Bug-free CRUD for every model
   - Loading, empty, and error states

--- a/ui/src/hooks/useCollectionDetail.ts
+++ b/ui/src/hooks/useCollectionDetail.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect } from "react";
 import apiClient from "@/lib/api";
-import { Collection, Entry, Site } from "@/types";
+import { Collection, Entry, Pagination, Site } from "@/types";
 
 interface CollectionDetailData {
   collection: Collection;
   entries: Entry[];
   site: Site;
+  pagination: Pagination;
 }
 
 export function useCollectionDetail(
@@ -15,6 +16,7 @@ export function useCollectionDetail(
   const [data, setData] = useState<CollectionDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     if (!collectionId || !siteId) {
@@ -31,13 +33,14 @@ export function useCollectionDetail(
         // Fetch collection, entries, and site info in parallel
         const [collectionResponse, entriesResponse, siteResponse] = await Promise.all([
           apiClient.get(`/collections/${collectionId}`),
-          apiClient.get(`/collections/${collectionId}/entries`),
+          apiClient.get(`/collections/${collectionId}/entries`, { params: { page, limit: 20 } }),
           apiClient.get(`/sites/${siteId}`)
         ]);
 
         setData({
           collection: collectionResponse.data,
-          entries: entriesResponse.data,
+          entries: entriesResponse.data.entries,
+          pagination: entriesResponse.data.pagination,
           site: siteResponse.data.site
         });
       } catch (err: any) {
@@ -48,11 +51,13 @@ export function useCollectionDetail(
     };
 
     fetchCollectionDetail();
-  }, [collectionId, siteId]);
+  }, [collectionId, siteId, page]);
 
   return {
     collection: data?.collection || null,
     entries: data?.entries || [],
+    pagination: data?.pagination || { page: 1, limit: 20, total: 0, totalPages: 0 },
+    setPage,
     site: data?.site || null,
     loading,
     error

--- a/ui/src/pages/collections/Detail.tsx
+++ b/ui/src/pages/collections/Detail.tsx
@@ -8,7 +8,7 @@ import useDelete from "@/hooks/useDelete";
 
 const CollectionDetailsPage: React.FC = () => {
   const { id, siteId } = useParams<{ id: string; siteId: string }>();
-  const { collection, entries, site, loading, error } = useCollectionDetail(
+  const { collection, entries, site, pagination, setPage, loading, error } = useCollectionDetail(
     id,
     siteId,
   );
@@ -192,6 +192,27 @@ const CollectionDetailsPage: React.FC = () => {
                 Create First Entry
               </button>
             </div>
+          </div>
+        )}
+        {pagination.totalPages > 1 && (
+          <div className="flex items-center justify-center gap-3 pt-4">
+            <button
+              className="btn btn-sm"
+              disabled={pagination.page <= 1}
+              onClick={() => setPage(pagination.page - 1)}
+            >
+              Previous
+            </button>
+            <span className="text-sm text-bare-600">
+              Page {pagination.page} of {pagination.totalPages} · {pagination.total} entries
+            </span>
+            <button
+              className="btn btn-sm"
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => setPage(pagination.page + 1)}
+            >
+              Next
+            </button>
           </div>
         )}
       </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -24,6 +24,13 @@ export interface Entry {
     data: Record<string, any>;
 }
 
+export interface Pagination {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+}
+
 export interface User {
     id: string;
     email: string;


### PR DESCRIPTION
## Summary

- paginate collection entries at the database layer
- return a stable entries and pagination metadata envelope
- default to 20 entries and cap client limits at 100
- validate page and limit query parameters
- add editor previous/next controls and total counts
- preserve the current public site-data behavior
- document the response contract and update the roadmap

## Verification

- `npm run lint`
- `npm run build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- pagination parameter bounds
- database page size, total count, total pages, and requested page metadata
