### PR TITLE
fix: add health and readiness guarantees

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ COPY --from=builder /app/barecms .
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/readyz || exit 1
+
 ENTRYPOINT [ "./barecms" ]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,10 @@ func (app *App) setup() {
 	if err := cfg.Validate(); err != nil {
 		panic(fmt.Sprintf("Invalid configuration: %v", err))
 	}
-	svc := services.NewService(cfg)
+	svc, err := services.NewService(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to initialize storage: %v", err))
+	}
 	r := router.Setup(svc, cfg)
 	app.router = r
 	app.cfg = cfg

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,6 +44,10 @@ curl -X GET http://localhost:8080/api/health
 }
 ```
 
+Operational deployments should use `GET /healthz` for process liveness and
+`GET /readyz` for traffic readiness. The readiness probe returns `503` while
+PostgreSQL is unavailable. `/api/health` remains available for compatibility.
+
 ### Get Site Data
 
 Retrieve all site content publicly without authentication. This is the primary endpoint for headless usage.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -76,6 +76,14 @@ The Compose configuration mounts `/app/uploads` in a named `uploads_data`
 volume. Back up this volume together with PostgreSQL; database-only backups do
 not contain uploaded media.
 
+BareCMS exposes two operational probes:
+
+- `GET /healthz` confirms that the HTTP process is alive.
+- `GET /readyz` confirms that the process can reach PostgreSQL.
+
+The published container health check uses `/readyz`, so orchestrators do not
+route traffic to an instance while its database is unavailable.
+
 💡 **Generate a secure JWT secret:**
 
 ```bash

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"barecms/configs"
 	"barecms/internal/services"
+	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -39,4 +41,13 @@ func NewHandler(service *services.Service, config configs.AppConfig) *Handler {
 
 func (h *Handler) Health(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "up"})
+}
+
+func (h *Handler) Readiness(c echo.Context) error {
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 2*time.Second)
+	defer cancel()
+	if h.Service == nil || h.Service.Storage == nil || h.Service.Storage.Ping(ctx) != nil {
+		return c.JSON(http.StatusServiceUnavailable, echo.Map{"status": "unavailable"})
+	}
+	return c.JSON(http.StatusOK, echo.Map{"status": "ready"})
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -34,6 +34,8 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	}))
 
 	h := handlers.NewHandler(service, config)
+	r.GET("/healthz", h.Health)
+	r.GET("/readyz", h.Readiness)
 	api := r.Group("/api")
 	api.GET("/health", h.Health)
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -72,3 +72,21 @@ func TestAuthRateLimit(t *testing.T) {
 		t.Fatalf("expected second auth request to return 429, got %d", second.Code)
 	}
 }
+
+func TestReadinessFailsWithoutStorage(t *testing.T) {
+	router := Setup(nil, testConfig())
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", response.Code)
+	}
+}
+
+func TestLivenessDoesNotDependOnStorage(t *testing.T) {
+	router := Setup(nil, testConfig())
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -3,7 +3,6 @@ package services
 import (
 	"barecms/configs"
 	"barecms/internal/storage"
-	"fmt"
 )
 
 type Service struct {
@@ -11,10 +10,10 @@ type Service struct {
 	Config  configs.AppConfig
 }
 
-func NewService(config configs.AppConfig) *Service {
+func NewService(config configs.AppConfig) (*Service, error) {
 	storage, err := storage.NewStorage(config.DatabaseURL)
 	if err != nil {
-		fmt.Println("Failed to create storage:", err)
+		return nil, err
 	}
-	return &Service{Storage: storage, Config: config}
+	return &Service{Storage: storage, Config: config}, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,14 @@ import (
 
 type Storage struct {
 	DB *gorm.DB
+}
+
+func (s *Storage) Ping(ctx context.Context) error {
+	database, err := s.DB.DB()
+	if err != nil {
+		return err
+	}
+	return database.PingContext(ctx)
 }
 
 func NewStorage(databaseURL string) (*Storage, error) {

--- a/roadmap.md
+++ b/roadmap.md
@@ -52,7 +52,8 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [ ] **Docker docs**
   - Document every environment variable
   - Provide `.env.production` example
-  - Add a `/healthz` endpoint
+  - [x] Add liveness `/healthz`, database readiness `/readyz`, and container health check (`reliability/health-readiness`)
+  - [x] Fail startup when database initialization fails
   - Slim final image with multi-stage build
 
 ## Phase 2. MCP-native pivot


### PR DESCRIPTION
## Summary

- add process liveness at `/healthz`
- add database-backed readiness at `/readyz` with a two-second timeout
- retain `/api/health` compatibility
- fail startup when storage initialization fails
- add a production container health check
- document probe behavior for self-hosters
- update the live roadmap

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- liveness remains healthy without storage
- readiness returns 503 without working storage
