### PR TITLE
fix: make destructive cascades transactional

### DIFF
--- a/internal/services/collections.go
+++ b/internal/services/collections.go
@@ -74,15 +74,7 @@ func (s *Service) DeleteCollection(collectionID, userID string) error {
 		return err
 	}
 
-	if err := s.Storage.DeleteEntriesByCollectionID(collectionID); err != nil {
-		return err
-	}
-
-	if err := s.Storage.DeleteCollection(collectionID); err != nil {
-		return err
-	}
-
-	return nil
+	return s.Storage.DeleteCollection(collectionID)
 }
 
 func mapToCollectionDB(collection models.Collection, fieldsJSON []byte) storage.CollectionDB {

--- a/internal/services/sites.go
+++ b/internal/services/sites.go
@@ -6,6 +6,9 @@ import (
 	"barecms/internal/utils"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
 )
 
 func (s *Service) GetSites(userID string) ([]models.Site, error) {
@@ -75,28 +78,14 @@ func (s *Service) DeleteSite(id, userID string) error {
 		return err
 	}
 
-	if err := s.Storage.DeleteSite(id); err != nil {
-		return err
-	}
-
-	// Delete collections associated with the site ID
-	siteCollections, err := s.Storage.GetCollectionsBySiteID(id)
+	media, err := s.Storage.DeleteSiteCascade(id)
 	if err != nil {
 		return err
 	}
-	var collectionIds []string
-	for _, collection := range siteCollections {
-		collectionIds = append(collectionIds, collection.ID)
-	}
-
-	// Delete entries associated with the collection IDs
-	if err := s.Storage.DeleteEntriesByCollectionIDs(collectionIds); err != nil {
-		return err
-	}
-
-	// Delete collections
-	if err := s.Storage.DeleteCollectionsBySiteID(id); err != nil {
-		return err
+	for _, file := range media {
+		if err := os.Remove(filepath.Join(s.Config.UploadsDir, file.StoredName)); err != nil && !os.IsNotExist(err) {
+			slog.Warn("Could not remove deleted site's media file", "file", file.StoredName, "error", err)
+		}
 	}
 	return nil
 }

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -3,6 +3,9 @@ package services
 import (
 	"barecms/internal/models"
 	"barecms/internal/storage"
+	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -19,59 +22,15 @@ func (s *Service) GetUser(userID string) (models.User, error) {
 }
 
 func (s *Service) DeleteUser(userID string) error {
-	// Delete user resources first
-	if err := s.DeleteUserResources(userID); err != nil {
-		return errors.Wrap(err, "failed to delete user resources")
-	}
-
-	// Finally, delete the user itself
-	if err := s.Storage.DeleteUserByID(userID); err != nil {
+	media, err := s.Storage.DeleteUserCascade(userID)
+	if err != nil {
 		return errors.Wrap(err, "failed to delete user")
 	}
-
-	return nil
-}
-
-func (s *Service) DeleteUserResources(userID string) error {
-	// Get sites owned by the user
-	userSites, err := s.Storage.GetSitesByUserID(userID)
-	if err != nil {
-		return errors.Wrap(err, "failed to get user sites")
-	}
-	var siteIDs []string
-	for _, site := range userSites {
-		siteIDs = append(siteIDs, site.ID)
-	}
-
-	// Get collections from the sites
-	siteCollections, err := s.Storage.GetCollectionsFromSitesIDs(siteIDs)
-	if err != nil {
-		return errors.Wrap(err, "failed to get collections from sites")
-	}
-	var collectionIDs []string
-	for _, collection := range siteCollections {
-		collectionIDs = append(collectionIDs, collection.ID)
-	}
-
-	// Delete entries by collection IDs
-	if len(collectionIDs) > 0 {
-		if err := s.Storage.DeleteEntriesByCollectionIDs(collectionIDs); err != nil {
-			return errors.Wrap(err, "failed to delete entries")
+	for _, file := range media {
+		if err := os.Remove(filepath.Join(s.Config.UploadsDir, file.StoredName)); err != nil && !os.IsNotExist(err) {
+			slog.Warn("Could not remove deleted user's media file", "file", file.StoredName, "error", err)
 		}
 	}
-
-	// Delete collections by site IDs
-	if len(siteIDs) > 0 {
-		if err := s.Storage.DeleteCollectionsBySiteIDs(siteIDs); err != nil {
-			return errors.Wrap(err, "failed to delete collections")
-		}
-	}
-
-	// Delete sites by user ID
-	if err := s.Storage.DeleteSitesByUserID(userID); err != nil {
-		return errors.Wrap(err, "failed to delete sites")
-	}
-
 	return nil
 }
 

--- a/internal/storage/cascade_test.go
+++ b/internal/storage/cascade_test.go
@@ -1,0 +1,112 @@
+package storage
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func cascadeTestStorage(t *testing.T) *Storage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}, &MediaFileDB{}); err != nil {
+		t.Fatal(err)
+	}
+	return &Storage{DB: db}
+}
+
+func TestDeleteSiteCascadeRemovesAllDatabaseResources(t *testing.T) {
+	storage := cascadeTestStorage(t)
+	for _, record := range []any{
+		&SiteDB{ID: "site", Name: "Site", Slug: "site", UserID: "user"},
+		&CollectionDB{ID: "collection", Name: "Posts", Slug: "posts", SiteID: "site"},
+		&EntryDB{ID: "entry", CollectionID: "collection", Data: []byte(`{}`)},
+		&MediaFileDB{ID: "media", SiteID: "site", StoredName: "media.png", OriginalName: "image.png", MIMEType: "image/png", Size: 1},
+	} {
+		if err := storage.DB.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	media, err := storage.DeleteSiteCascade("site")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(media) != 1 || media[0].StoredName != "media.png" {
+		t.Fatalf("unexpected media: %+v", media)
+	}
+	for name, model := range map[string]any{"sites": &SiteDB{}, "collections": &CollectionDB{}, "entries": &EntryDB{}, "media": &MediaFileDB{}} {
+		var count int64
+		if err := storage.DB.Model(model).Count(&count).Error; err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Errorf("expected no %s, got %d", name, count)
+		}
+	}
+}
+
+func TestDeleteUserCascadeRemovesOwnedGraph(t *testing.T) {
+	storage := cascadeTestStorage(t)
+	if err := storage.DB.AutoMigrate(&UserDB{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range []any{
+		&UserDB{ID: "user", Email: "user@example.com", Username: "user", Password: "hash"},
+		&SiteDB{ID: "site", Name: "Site", Slug: "site", UserID: "user"},
+		&CollectionDB{ID: "collection", Name: "Posts", Slug: "posts", SiteID: "site"},
+		&EntryDB{ID: "entry", CollectionID: "collection", Data: []byte(`{}`)},
+		&MediaFileDB{ID: "media", SiteID: "site", StoredName: "media.png", OriginalName: "image.png", MIMEType: "image/png", Size: 1},
+	} {
+		if err := storage.DB.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	media, err := storage.DeleteUserCascade("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(media) != 1 {
+		t.Fatalf("unexpected media: %+v", media)
+	}
+	for name, model := range map[string]any{"users": &UserDB{}, "sites": &SiteDB{}, "collections": &CollectionDB{}, "entries": &EntryDB{}, "media": &MediaFileDB{}} {
+		var count int64
+		if err := storage.DB.Model(model).Count(&count).Error; err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Errorf("expected no %s, got %d", name, count)
+		}
+	}
+}
+
+func TestDeleteSiteCascadeRollsBackOnFailure(t *testing.T) {
+	storage := cascadeTestStorage(t)
+	for _, record := range []any{
+		&SiteDB{ID: "site", Name: "Site", Slug: "site", UserID: "user"},
+		&CollectionDB{ID: "collection", Name: "Posts", Slug: "posts", SiteID: "site"},
+		&EntryDB{ID: "entry", CollectionID: "collection", Data: []byte(`{}`)},
+	} {
+		if err := storage.DB.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := storage.DB.Exec(`CREATE TRIGGER prevent_collection_delete BEFORE DELETE ON collections BEGIN SELECT RAISE(FAIL, 'blocked'); END`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := storage.DeleteSiteCascade("site"); err == nil {
+		t.Fatal("expected cascade failure")
+	}
+	for name, model := range map[string]any{"sites": &SiteDB{}, "collections": &CollectionDB{}, "entries": &EntryDB{}} {
+		var count int64
+		if err := storage.DB.Model(model).Count(&count).Error; err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("expected rollback to preserve %s, got %d", name, count)
+		}
+	}
+}

--- a/internal/storage/sites.go
+++ b/internal/storage/sites.go
@@ -1,5 +1,7 @@
 package storage
 
+import "gorm.io/gorm"
+
 func (s *Storage) CreateSite(site SiteDB) error {
 	created := s.DB.Create(&site)
 	if created.Error != nil {
@@ -32,6 +34,34 @@ func (s *Storage) DeleteSite(id string) error {
 		return deleted.Error
 	}
 	return nil
+}
+
+func (s *Storage) DeleteSiteCascade(id string) ([]MediaFileDB, error) {
+	var media []MediaFileDB
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("site_id = ?", id).Find(&media).Error; err != nil {
+			return err
+		}
+		collectionIDs := tx.Model(&CollectionDB{}).Select("id").Where("site_id = ?", id)
+		if err := tx.Where("collection_id IN (?)", collectionIDs).Delete(&EntryDB{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("site_id = ?", id).Delete(&CollectionDB{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("site_id = ?", id).Delete(&MediaFileDB{}).Error; err != nil {
+			return err
+		}
+		result := tx.Where("id = ?", id).Delete(&SiteDB{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+	return media, err
 }
 
 func (s *Storage) DeleteSitesByUserID(userID string) error {

--- a/internal/storage/user.go
+++ b/internal/storage/user.go
@@ -1,6 +1,9 @@
 package storage
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
 
 func (s *Storage) CreateUser(user UserDB) error {
 	created := s.DB.Create(&user)
@@ -47,4 +50,36 @@ func (s *Storage) DeleteUserByID(id string) error {
 	}
 	// todo: delete all user resources
 	return nil
+}
+
+func (s *Storage) DeleteUserCascade(id string) ([]MediaFileDB, error) {
+	var media []MediaFileDB
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		siteIDs := tx.Model(&SiteDB{}).Select("id").Where("user_id = ?", id)
+		collectionIDs := tx.Model(&CollectionDB{}).Select("id").Where("site_id IN (?)", siteIDs)
+		if err := tx.Where("site_id IN (?)", siteIDs).Find(&media).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("collection_id IN (?)", collectionIDs).Delete(&EntryDB{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("site_id IN (?)", siteIDs).Delete(&CollectionDB{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("site_id IN (?)", siteIDs).Delete(&MediaFileDB{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id = ?", id).Delete(&SiteDB{}).Error; err != nil {
+			return err
+		}
+		result := tx.Where("id = ?", id).Delete(&UserDB{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+	return media, err
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -45,6 +45,12 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - Lock response shapes for sites, collections, entries
   - [x] Bounded pagination and metadata for collection entries (`feature/api-pagination`)
   - [ ] Pagination on remaining authenticated list endpoints
+- [ ] **Database integrity and migrations**
+  - [x] Transactional site, collection, and account deletion (`reliability/database-integrity`)
+  - [x] Cascade media metadata cleanup with best-effort disk cleanup
+  - [x] Rollback regression coverage for failed destructive operations
+  - [ ] Versioned migrations and upgrade tests
+  - [ ] Scoped uniqueness and foreign-key constraints
 - [ ] **UI polish**
   - Bug-free CRUD for every model
   - Loading, empty, and error states


### PR DESCRIPTION
## Summary

- make site deletion a single database transaction
- make account deletion a single database transaction
- remove duplicate entry deletion from collection deletion
- cascade entries, collections, and media metadata consistently
- remove associated media files after successful database commits
- treat disk cleanup as best-effort and log failures without corrupting database state
- update the live roadmap

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- complete site graph deletion
- complete account-owned graph deletion
- transaction rollback preserves the entire graph when a child deletion fails

## Follow-up

Versioned migrations, scoped unique indexes, and foreign-key constraints remain a separate upgrade-safety milestone.
