### PR TITLE
feat: add versioned database migrations

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -84,6 +84,17 @@ BareCMS exposes two operational probes:
 The published container health check uses `/readyz`, so orchestrators do not
 route traffic to an instance while its database is unavailable.
 
+## Database upgrades
+
+BareCMS applies numbered database migrations during startup and records them in
+the `schema_migrations` table. Back up PostgreSQL and the uploads volume before
+upgrading. Never run two different BareCMS versions against the same database
+during an upgrade; update the application container, allow migrations to
+finish, confirm `/readyz`, and only then remove the previous image.
+
+Migration failures stop startup without recording the failed version. Restore
+the backup before downgrading because automatic down-migrations are not run.
+
 💡 **Generate a secure JWT secret:**
 
 ```bash

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"fmt"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+type migration struct {
+	version string
+	up      func(*gorm.DB) error
+}
+
+var migrations = []migration{
+	{version: "001_baseline", up: func(db *gorm.DB) error {
+		return db.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}, &UserDB{}, &MediaFileDB{})
+	}},
+	{version: "002_scoped_collection_indexes", up: migrateCollectionIndexes},
+}
+
+func runMigrations(db *gorm.DB) error {
+	if err := db.AutoMigrate(&SchemaMigrationDB{}); err != nil {
+		return fmt.Errorf("create migration ledger: %w", err)
+	}
+	for _, item := range migrations {
+		var count int64
+		if err := db.Model(&SchemaMigrationDB{}).Where("version = ?", item.version).Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			if err := item.up(tx); err != nil {
+				return err
+			}
+			return tx.Create(&SchemaMigrationDB{Version: item.version}).Error
+		}); err != nil {
+			return fmt.Errorf("apply migration %s: %w", item.version, err)
+		}
+		slog.Info("Database migration applied", "version", item.version)
+	}
+	return nil
+}
+
+func migrateCollectionIndexes(db *gorm.DB) error {
+	migrator := db.Migrator()
+	if migrator.HasIndex(&CollectionDB{}, "idx_collections_slug") {
+		if err := migrator.DropIndex(&CollectionDB{}, "idx_collections_slug"); err != nil {
+			return err
+		}
+	}
+	if !migrator.HasIndex(&CollectionDB{}, "idx_collections_site_slug") {
+		if err := migrator.CreateIndex(&CollectionDB{}, "idx_collections_site_slug"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -1,0 +1,85 @@
+package storage
+
+import (
+	"testing"
+
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type legacyCollection struct {
+	ID     string         `gorm:"primaryKey"`
+	SiteID string         `gorm:"not null"`
+	Slug   string         `gorm:"uniqueIndex;not null"`
+	Name   string         `gorm:"not null"`
+	Fields datatypes.JSON `gorm:"type:jsonb"`
+}
+
+func (legacyCollection) TableName() string { return "collections" }
+
+func migrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestMigrationsAreIdempotent(t *testing.T) {
+	db := migrationTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("second migration run failed: %v", err)
+	}
+	var count int64
+	if err := db.Model(&SchemaMigrationDB{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != int64(len(migrations)) {
+		t.Fatalf("expected %d migrations, got %d", len(migrations), count)
+	}
+}
+
+func TestCollectionSlugIsUniqueWithinSite(t *testing.T) {
+	db := migrationTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	for _, site := range []SiteDB{{ID: "one", Name: "One", Slug: "one", UserID: "user"}, {ID: "two", Name: "Two", Slug: "two", UserID: "user"}} {
+		if err := db.Create(&site).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Create(&CollectionDB{ID: "one-posts", SiteID: "one", Name: "Posts", Slug: "posts"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&CollectionDB{ID: "two-posts", SiteID: "two", Name: "Posts", Slug: "posts"}).Error; err != nil {
+		t.Fatalf("same slug in another site should be allowed: %v", err)
+	}
+	if err := db.Create(&CollectionDB{ID: "duplicate", SiteID: "one", Name: "Other", Slug: "posts"}).Error; err == nil {
+		t.Fatal("duplicate slug in one site should be rejected")
+	}
+}
+
+func TestMigrationsUpgradeLegacyGlobalCollectionIndex(t *testing.T) {
+	db := migrationTestDB(t)
+	if err := db.AutoMigrate(&SiteDB{}, &legacyCollection{}); err != nil {
+		t.Fatal(err)
+	}
+	if !db.Migrator().HasIndex(&legacyCollection{}, "idx_collections_slug") {
+		t.Fatal("legacy index was not created")
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatal(err)
+	}
+	if db.Migrator().HasIndex(&CollectionDB{}, "idx_collections_slug") {
+		t.Fatal("legacy global index still exists")
+	}
+	if !db.Migrator().HasIndex(&CollectionDB{}, "idx_collections_site_slug") {
+		t.Fatal("scoped index was not created")
+	}
+}

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -8,7 +8,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type legacyCollection struct {
+type preMigrationCollectionSchema struct {
 	ID     string         `gorm:"primaryKey"`
 	SiteID string         `gorm:"not null"`
 	Slug   string         `gorm:"uniqueIndex;not null"`
@@ -16,7 +16,7 @@ type legacyCollection struct {
 	Fields datatypes.JSON `gorm:"type:jsonb"`
 }
 
-func (legacyCollection) TableName() string { return "collections" }
+func (preMigrationCollectionSchema) TableName() string { return "collections" }
 
 func migrationTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -67,10 +67,10 @@ func TestCollectionSlugIsUniqueWithinSite(t *testing.T) {
 
 func TestMigrationsUpgradeLegacyGlobalCollectionIndex(t *testing.T) {
 	db := migrationTestDB(t)
-	if err := db.AutoMigrate(&SiteDB{}, &legacyCollection{}); err != nil {
+	if err := db.AutoMigrate(&SiteDB{}, &preMigrationCollectionSchema{}); err != nil {
 		t.Fatal(err)
 	}
-	if !db.Migrator().HasIndex(&legacyCollection{}, "idx_collections_slug") {
+	if !db.Migrator().HasIndex(&preMigrationCollectionSchema{}, "idx_collections_slug") {
 		t.Fatal("legacy index was not created")
 	}
 	if err := runMigrations(db); err != nil {

--- a/internal/storage/schemas.go
+++ b/internal/storage/schemas.go
@@ -20,8 +20,8 @@ func (SiteDB) TableName() string {
 type CollectionDB struct {
 	ID      string         `gorm:"primaryKey"`
 	Name    string         `gorm:"not null"`
-	Slug    string         `gorm:"uniqueIndex;not null"`
-	SiteID  string         `gorm:"not null"`
+	Slug    string         `gorm:"not null;uniqueIndex:idx_collections_site_slug,priority:2"`
+	SiteID  string         `gorm:"not null;index;uniqueIndex:idx_collections_site_slug,priority:1"`
 	Fields  datatypes.JSON `gorm:"type:jsonb"`
 	Entries []EntryDB      `gorm:"foreignKey:CollectionID"`
 }
@@ -32,7 +32,7 @@ func (CollectionDB) TableName() string {
 
 type EntryDB struct {
 	ID           string         `gorm:"primaryKey"`
-	CollectionID string         `gorm:"not null"`
+	CollectionID string         `gorm:"not null;index"`
 	Data         datatypes.JSON `gorm:"type:jsonb"`
 }
 
@@ -62,3 +62,10 @@ func (MediaFileDB) TableName() string { return "media_files" }
 func (UserDB) TableName() string {
 	return "users"
 }
+
+type SchemaMigrationDB struct {
+	Version   string    `gorm:"primaryKey"`
+	AppliedAt time.Time `gorm:"autoCreateTime"`
+}
+
+func (SchemaMigrationDB) TableName() string { return "schema_migrations" }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -39,12 +39,10 @@ func openDatabase(url string) (*gorm.DB, error) {
 		return nil, errors.Wrap(err, "failed to connect to database")
 	}
 
-	// Migrate the schema
-	if err := database.AutoMigrate(&SiteDB{}, &CollectionDB{}, &EntryDB{}, &UserDB{}, &MediaFileDB{}); err != nil {
+	if err := runMigrations(database); err != nil {
 		return nil, errors.Wrap(err, "failed to migrate database schema")
 	}
-
-	slog.Info("Database migrated successfully.")
+	slog.Info("Database migrations are current.")
 
 	return database, nil
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -49,8 +49,9 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - [x] Transactional site, collection, and account deletion (`reliability/database-integrity`)
   - [x] Cascade media metadata cleanup with best-effort disk cleanup
   - [x] Rollback regression coverage for failed destructive operations
-  - [ ] Versioned migrations and upgrade tests
-  - [ ] Scoped uniqueness and foreign-key constraints
+  - [x] Versioned migration ledger, idempotency, and legacy upgrade tests (`reliability/versioned-migrations`)
+  - [x] Collection slug uniqueness scoped to its site
+  - [ ] Foreign-key constraints
 - [ ] **UI polish**
   - Bug-free CRUD for every model
   - Loading, empty, and error states


### PR DESCRIPTION
## Summary

- replace untracked startup schema mutation with numbered migrations
- add a `schema_migrations` ledger
- run each pending migration transactionally and record it only on success
- keep migration execution idempotent
- scope collection slug uniqueness to each site
- add collection and entry lookup indexes
- document safe self-hosted upgrade and downgrade expectations
- update the live roadmap

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- clean database migration
- repeated migration execution
- scoped collection uniqueness behavior
- upgrade from the legacy global collection-slug index
