### PR TITLE
feat: complete site and collection editing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -155,6 +155,17 @@ collection schema before it replaces the existing entry data.
 
 `page` starts at 1 and `limit` is capped at 100.
 
+### Update a site
+
+`PUT /api/sites/:siteId` accepts `{ "name": "New name" }`. The public slug is
+intentionally stable so renaming a site does not break consumers.
+
+### Update a collection
+
+`PUT /api/collections/:collectionId` accepts `name` and the complete `fields`
+schema. Collection slugs remain stable. Schema changes are rejected with a
+`422 validation_failed` response if any existing entry would become invalid.
+
 ## 🔐 Authentication Endpoints
 
 ### Register User

--- a/internal/handlers/collections.go
+++ b/internal/handlers/collections.go
@@ -54,3 +54,15 @@ func (h *Handler) DeleteCollection(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "Collection deleted!"})
 }
+
+func (h *Handler) UpdateCollection(c echo.Context) error {
+	var request models.UpdateCollectionRequest
+	if err := c.Bind(&request); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	collection, err := h.Service.UpdateCollection(c.Param("id"), currentUserID(c), request)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, collection)
+}

--- a/internal/handlers/sites.go
+++ b/internal/handlers/sites.go
@@ -62,6 +62,18 @@ func (h *Handler) DeleteSite(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"message": "Site deleted!"})
 }
 
+func (h *Handler) UpdateSite(c echo.Context) error {
+	var request models.UpdateSiteRequest
+	if err := c.Bind(&request); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	site, err := h.Service.UpdateSite(c.Param("id"), currentUserID(c), request)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, map[string]models.Site{"site": site})
+}
+
 func (h *Handler) GetSiteData(c echo.Context) error {
 	slug := c.Param("siteSlug")
 

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -14,3 +14,8 @@ type CreateCollectionRequest struct {
 	Name   string  `json:"name"`
 	Fields []Field `json:"fields"`
 }
+
+type UpdateCollectionRequest struct {
+	Name   string  `json:"name"`
+	Fields []Field `json:"fields"`
+}

--- a/internal/models/site.go
+++ b/internal/models/site.go
@@ -12,6 +12,10 @@ type CreateSiteRequest struct {
 	UserID string `json:"userId"`
 }
 
+type UpdateSiteRequest struct {
+	Name string `json:"name"`
+}
+
 type SiteData struct {
 	ID   string                 `json:"id"`
 	Name string                 `json:"name"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -67,6 +67,7 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	protected.GET("/sites/:id", h.GetSite)
 	protected.GET("/sites/:id/collections", h.GetSiteWithCollections)
 	protected.POST("/sites", h.CreateSite)
+	protected.PUT("/sites/:id", h.UpdateSite)
 	protected.DELETE("/sites/:id", h.DeleteSite)
 	protected.GET("/sites/:siteId/files", h.ListMedia)
 	protected.POST("/sites/:siteId/files", h.UploadMedia)
@@ -75,6 +76,7 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	// Collections routes
 	protected.POST("/collections", h.CreateCollection)
 	protected.GET("/collections/:id", h.GetCollection)
+	protected.PUT("/collections/:id", h.UpdateCollection)
 	protected.GET("/collections/:id/entries", h.GetCollectionEntries)
 	protected.GET("/collections/site/:id", h.GetCollectionsBySiteID)
 	protected.DELETE("/collections/:id", h.DeleteCollection)

--- a/internal/services/collections.go
+++ b/internal/services/collections.go
@@ -6,7 +6,6 @@ import (
 	"barecms/internal/utils"
 	"encoding/json"
 
-	"github.com/pkg/errors"
 	"gorm.io/datatypes"
 )
 
@@ -15,11 +14,8 @@ func (s *Service) CreateCollection(request models.CreateCollectionRequest, userI
 		return err
 	}
 
-	// Validate field types
-	for _, field := range request.Fields {
-		if !models.IsValidFieldType(string(field.Type)) {
-			return errors.New("invalid field type: " + string(field.Type))
-		}
+	if err := validateCollectionSchema(request.Name, request.Fields); err != nil {
+		return err
 	}
 
 	// Convert fields to JSON for storage
@@ -40,6 +36,32 @@ func (s *Service) CreateCollection(request models.CreateCollectionRequest, userI
 		return err
 	}
 	return nil
+}
+
+func (s *Service) UpdateCollection(id, userID string, request models.UpdateCollectionRequest) (models.Collection, error) {
+	if err := s.requireCollectionOwner(userID, id); err != nil {
+		return models.Collection{}, err
+	}
+	if err := validateCollectionSchema(request.Name, request.Fields); err != nil {
+		return models.Collection{}, err
+	}
+	entries, err := s.Storage.GetEntriesByCollectionID(id)
+	if err != nil {
+		return models.Collection{}, err
+	}
+	for _, entry := range entries {
+		if err := validateEntryData(json.RawMessage(entry.Data), request.Fields); err != nil {
+			return models.Collection{}, &ValidationError{Fields: map[string]string{"fields": "schema is incompatible with existing entry " + entry.ID}}
+		}
+	}
+	fieldsJSON, err := json.Marshal(request.Fields)
+	if err != nil {
+		return models.Collection{}, err
+	}
+	if err := s.Storage.UpdateCollection(id, request.Name, datatypes.JSON(fieldsJSON)); err != nil {
+		return models.Collection{}, err
+	}
+	return s.GetCollectionByID(id, userID)
 }
 
 func (s *Service) GetCollectionByID(collectionID, userID string) (models.Collection, error) {

--- a/internal/services/resource_updates_test.go
+++ b/internal/services/resource_updates_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"errors"
+	"testing"
+)
+
+func TestUpdateSiteKeepsSlugAndEnforcesOwnership(t *testing.T) {
+	service := entryTestService(t)
+	if _, err := service.UpdateSite("site-1", "another-user", models.UpdateSiteRequest{Name: "Renamed"}); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+	updated, err := service.UpdateSite("site-1", "owner-1", models.UpdateSiteRequest{Name: "Renamed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "Renamed" || updated.Slug != "site" {
+		t.Fatalf("unexpected site: %+v", updated)
+	}
+}
+
+func TestUpdateCollectionProtectsExistingEntries(t *testing.T) {
+	service := entryTestService(t)
+	compatible := models.UpdateCollectionRequest{Name: "Articles", Fields: []models.Field{
+		{Name: "title", Type: models.FieldTypeString},
+		{Name: "image", Type: models.FieldTypeImage, Optional: true},
+	}}
+	updated, err := service.UpdateCollection("collection-1", "owner-1", compatible)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "Articles" || updated.Slug != "posts" || len(updated.Fields) != 2 {
+		t.Fatalf("unexpected collection: %+v", updated)
+	}
+
+	incompatible := models.UpdateCollectionRequest{Name: "Articles", Fields: []models.Field{
+		{Name: "title", Type: models.FieldTypeString},
+		{Name: "author", Type: models.FieldTypeString},
+	}}
+	if _, err := service.UpdateCollection("collection-1", "owner-1", incompatible); err == nil {
+		t.Fatal("expected incompatible schema to be rejected")
+	}
+}

--- a/internal/services/sites.go
+++ b/internal/services/sites.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func (s *Service) GetSites(userID string) ([]models.Site, error) {
@@ -59,6 +60,9 @@ func (s *Service) GetSiteWithCollections(id, userID string) (map[string]interfac
 }
 
 func (s *Service) CreateSite(request models.CreateSiteRequest, userID string) error {
+	if strings.TrimSpace(request.Name) == "" {
+		return &ValidationError{Fields: map[string]string{"name": "is required"}}
+	}
 	newSite := models.Site{
 		ID:     utils.GenerateUniqueID(),
 		Name:   request.Name,
@@ -71,6 +75,24 @@ func (s *Service) CreateSite(request models.CreateSiteRequest, userID string) er
 	}
 
 	return nil
+}
+
+func (s *Service) UpdateSite(id, userID string, request models.UpdateSiteRequest) (models.Site, error) {
+	if err := s.requireSiteOwner(userID, id); err != nil {
+		return models.Site{}, err
+	}
+	name := strings.TrimSpace(request.Name)
+	if name == "" {
+		return models.Site{}, &ValidationError{Fields: map[string]string{"name": "is required"}}
+	}
+	if err := s.Storage.UpdateSiteName(id, name); err != nil {
+		return models.Site{}, err
+	}
+	site, err := s.Storage.GetSite(id)
+	if err != nil {
+		return models.Site{}, err
+	}
+	return mapToSite(site), nil
 }
 
 func (s *Service) DeleteSite(id, userID string) error {

--- a/internal/services/validation.go
+++ b/internal/services/validation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -80,4 +81,32 @@ func validateFieldValue(fieldType models.FieldType, value any) string {
 		}
 	}
 	return ""
+}
+
+func validateCollectionSchema(name string, fields []models.Field) error {
+	problems := make(map[string]string)
+	if strings.TrimSpace(name) == "" {
+		problems["name"] = "is required"
+	}
+	if len(fields) == 0 {
+		problems["fields"] = "must contain at least one field"
+	}
+	seen := make(map[string]bool, len(fields))
+	for index, field := range fields {
+		key := fmt.Sprintf("fields.%d", index)
+		fieldName := strings.TrimSpace(field.Name)
+		if fieldName == "" {
+			problems[key+".name"] = "is required"
+		} else if seen[fieldName] {
+			problems[key+".name"] = "must be unique"
+		}
+		seen[fieldName] = true
+		if !models.IsValidFieldType(string(field.Type)) {
+			problems[key+".type"] = "is invalid"
+		}
+	}
+	if len(problems) > 0 {
+		return &ValidationError{Fields: problems}
+	}
+	return nil
 }

--- a/internal/services/validation_test.go
+++ b/internal/services/validation_test.go
@@ -32,3 +32,19 @@ func TestValidateEntryData(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateCollectionSchemaRejectsInvalidDefinitions(t *testing.T) {
+	err := validateCollectionSchema("", []models.Field{
+		{Name: "title", Type: models.FieldTypeString},
+		{Name: "title", Type: "unknown"},
+	})
+	var validationError *ValidationError
+	if !errors.As(err, &validationError) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	for _, field := range []string{"name", "fields.1.name", "fields.1.type"} {
+		if validationError.Fields[field] == "" {
+			t.Errorf("expected error for %s", field)
+		}
+	}
+}

--- a/internal/storage/collections.go
+++ b/internal/storage/collections.go
@@ -1,5 +1,7 @@
 package storage
 
+import "gorm.io/datatypes"
+
 func (s *Storage) CreateCollection(collection CollectionDB) error {
 	created := s.DB.Create(&collection)
 	if created.Error != nil {
@@ -24,6 +26,10 @@ func (s *Storage) GetCollection(id string) (CollectionDB, error) {
 		return CollectionDB{}, retrieved.Error
 	}
 	return collection, nil
+}
+
+func (s *Storage) UpdateCollection(id, name string, fields datatypes.JSON) error {
+	return s.DB.Model(&CollectionDB{}).Where("id = ?", id).Updates(map[string]any{"name": name, "fields": fields}).Error
 }
 
 func (s *Storage) GetCollectionsBySiteID(siteID string) ([]CollectionDB, error) {

--- a/internal/storage/sites.go
+++ b/internal/storage/sites.go
@@ -28,6 +28,10 @@ func (s *Storage) GetSite(id string) (SiteDB, error) {
 	return site, nil
 }
 
+func (s *Storage) UpdateSiteName(id, name string) error {
+	return s.DB.Model(&SiteDB{}).Where("id = ?", id).Update("name", name).Error
+}
+
 func (s *Storage) DeleteSite(id string) error {
 	deleted := s.DB.Where("id = ?", id).Delete(&SiteDB{})
 	if deleted.Error != nil {

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,6 +18,10 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [x] **Entry editing workflow** (`feature/content-updates`)
   - Tenant-safe update endpoint with schema validation
   - Editor UI reusing typed controls and the media picker
+- [x] **Complete essential CRUD** (`feature/site-collection-updates`)
+  - Tenant-safe site renaming with stable public slugs
+  - Collection name/schema editing with existing-entry compatibility checks
+  - Minimal edit controls reusing existing modals
 
 ### Security and tenant isolation
 

--- a/ui/src/components/modals/CreateCollectionModal.tsx
+++ b/ui/src/components/modals/CreateCollectionModal.tsx
@@ -1,24 +1,35 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useApi } from "@/hooks/useApi";
 import { Field, FieldType, VALID_FIELD_TYPES } from "@/types/fields";
 
 interface CreateCollectionModalProps {
   siteId: string;
   dialogRef: React.RefObject<HTMLDialogElement>;
+  collectionId?: string;
+  initialName?: string;
+  initialFields?: Field[];
 }
 
 const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   siteId,
   dialogRef,
+  collectionId,
+  initialName = "",
+  initialFields = [],
 }) => {
-  const [collectionName, setCollectionName] = useState("");
-  const [fields, setFields] = useState<Field[]>([]);
+  const [collectionName, setCollectionName] = useState(initialName);
+  const [fields, setFields] = useState<Field[]>(initialFields);
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldType, setNewFieldType] = useState<FieldType>(FieldType.STRING);
   const [newFieldOptional, setNewFieldOptional] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null);
   const [fieldsError, setFieldsError] = useState<string | null>(null);
   const { request, loading } = useApi();
+
+  useEffect(() => {
+    setCollectionName(initialName);
+    setFields(initialFields);
+  }, [initialFields, initialName]);
 
   const handleCollectionNameChange = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -58,6 +69,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     ]);
     setNewFieldName("");
     setNewFieldType(FieldType.STRING);
+    setNewFieldOptional(false);
   };
 
   const removeField = (index: number) => {
@@ -86,8 +98,8 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     setFieldsError(null);
     try {
       await request({
-        url: "/collections",
-        method: "POST",
+        url: collectionId ? `/collections/${collectionId}` : "/collections",
+        method: collectionId ? "PUT" : "POST",
         data: {
           name: collectionName,
           fields,
@@ -95,7 +107,6 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
         },
       });
 
-      console.log("Collection created successfully");
       closeDialog();
       setTimeout(() => {
         window.location.reload();
@@ -104,15 +115,17 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       console.error(e);
       setError(e.message || "Failed to create collection. Please try again.");
     } finally {
-      setCollectionName("");
-      setFields([]);
+      if (!collectionId) {
+        setCollectionName("");
+        setFields([]);
+      }
     }
   };
 
   return (
     <dialog className="modal" ref={dialogRef}>
       <div className="modal-box">
-        <h3 className="font-bold text-lg mb-3">Create new collection</h3>
+        <h3 className="font-bold text-lg mb-3">{collectionId ? "Edit collection" : "Create new collection"}</h3>
         <input
           type="text"
           placeholder="Enter collection name"
@@ -177,7 +190,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
             onClick={handleSubmit}
             className="btn btn-primary"
           >
-            {loading ? "Creating..." : "Create"}
+            {loading ? "Saving..." : collectionId ? "Save changes" : "Create"}
           </button>
           <button className="btn" onClick={closeDialog}>
             Cancel

--- a/ui/src/components/modals/CreateSiteModal.tsx
+++ b/ui/src/components/modals/CreateSiteModal.tsx
@@ -2,15 +2,19 @@ import React, { useState } from "react";
 import { useApi } from "@/hooks/useApi";
 
 interface CreateSiteModalProps {
-  userId: string;
+  userId?: string;
   dialogRef: React.RefObject<HTMLDialogElement>;
+  siteId?: string;
+  initialName?: string;
 }
 
 const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
   userId,
   dialogRef,
+  siteId,
+  initialName = "",
 }) => {
-  const [siteName, setSiteName] = useState("");
+  const [siteName, setSiteName] = useState(initialName);
   const [error, setError] = useState<string | null>(null);
   const { request, loading } = useApi();
 
@@ -34,12 +38,11 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
 
     try {
       await request({
-        url: "/sites",
-        method: "POST",
+        url: siteId ? `/sites/${siteId}` : "/sites",
+        method: siteId ? "PUT" : "POST",
         data: { name: siteName, userId },
       });
 
-      console.log("Site created successfully");
       closeDialog();
       setTimeout(() => {
         window.location.reload();
@@ -48,14 +51,14 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
       console.error(e);
       setError(e.message || "Failed to create site. Please try again.");
     } finally {
-      setSiteName("");
+      if (!siteId) setSiteName("");
     }
   };
 
   return (
     <dialog className="modal" ref={dialogRef}>
       <div className="modal-box">
-        <h3 className="font-bold text-lg mb-2">Create new site</h3>
+        <h3 className="font-bold text-lg mb-2">{siteId ? "Edit site" : "Create new site"}</h3>
         <input
           type="text"
           placeholder="Enter site name"
@@ -70,7 +73,7 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
             onClick={handleSubmit}
             className="btn btn-primary"
           >
-            {loading ? "Creating..." : "Create"}
+            {loading ? "Saving..." : siteId ? "Save changes" : "Create"}
           </button>
           <button className="btn" onClick={closeDialog}>
             Cancel

--- a/ui/src/pages/collections/Detail.tsx
+++ b/ui/src/pages/collections/Detail.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import EntryCard from "@/components/cards/EntryCard";
 import Loader from "@/components/Loader";
 import CreateEntryModal from "@/components/modals/CreateEntryModal";
+import CreateCollectionModal from "@/components/modals/CreateCollectionModal";
 import { useCollectionDetail } from "@/hooks/useCollectionDetail";
 import useDelete from "@/hooks/useDelete";
 
@@ -19,6 +20,7 @@ const CollectionDetailsPage: React.FC = () => {
   );
 
   const entryModalRef = useRef<HTMLDialogElement>(null);
+  const editCollectionModalRef = useRef<HTMLDialogElement>(null);
 
   const openEntryModal = () => {
     if (entryModalRef.current) {
@@ -114,6 +116,14 @@ const CollectionDetailsPage: React.FC = () => {
             tabIndex={0}
             className="dropdown-content dropdown-bare menu bg-base-100 rounded-bare z-[1] p-2 w-40 shadow-bare-lg mt-2"
           >
+            <li>
+              <button
+                onClick={() => editCollectionModalRef.current?.showModal()}
+                className="text-sm w-full text-left"
+              >
+                Edit Collection
+              </button>
+            </li>
             <li>
               <button
                 onClick={handleDelete}
@@ -222,6 +232,13 @@ const CollectionDetailsPage: React.FC = () => {
         collectionId={collection.id}
         siteId={siteId as string}
         fields={collection.fields}
+      />
+      <CreateCollectionModal
+        siteId={siteId as string}
+        collectionId={collection.id}
+        initialName={collection.name}
+        initialFields={collection.fields}
+        dialogRef={editCollectionModalRef}
       />
     </div>
   );

--- a/ui/src/pages/sites/Detail.tsx
+++ b/ui/src/pages/sites/Detail.tsx
@@ -5,6 +5,7 @@ import { useSiteDetail } from "@/hooks/useSiteDetail";
 import Loader from "@/components/Loader";
 import useDelete from "@/hooks/useDelete";
 import ViewSiteDataModal from "@/components/modals/ViewSiteDataModal";
+import CreateSiteModal from "@/components/modals/CreateSiteModal";
 
 const SiteDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,6 +14,7 @@ const SiteDetailsPage: React.FC = () => {
 
   const collectionModalRef = useRef<HTMLDialogElement>(null);
   const viewDataModalRef = useRef<HTMLDialogElement>(null);
+  const editSiteModalRef = useRef<HTMLDialogElement>(null);
 
   const openCollectionModal = () => {
     if (collectionModalRef.current) {
@@ -110,6 +112,14 @@ const SiteDetailsPage: React.FC = () => {
             >
               <li>
                 <button
+                  onClick={() => editSiteModalRef.current?.showModal()}
+                  className="text-sm w-full text-left"
+                >
+                  Edit Site
+                </button>
+              </li>
+              <li>
+                <button
                   onClick={handleDelete}
                   className="text-sm text-error hover:bg-error/10 transition-colors w-full text-left"
                   disabled={isDeleting}
@@ -188,6 +198,7 @@ const SiteDetailsPage: React.FC = () => {
       </div>
 
       <CreateCollectionModal siteId={site.id} dialogRef={collectionModalRef} />
+      <CreateSiteModal siteId={site.id} initialName={site.name} dialogRef={editSiteModalRef} />
       <ViewSiteDataModal siteSlug={site.slug} dialogRef={viewDataModalRef} />
     </div>
   );


### PR DESCRIPTION
## Summary

- add tenant-safe site rename API and editor control
- keep public site slugs stable across renames
- add collection name and schema update API and editor control
- keep collection slugs stable across edits
- reject schema changes that invalidate existing entries
- use one collection schema validator for create and update paths
- reject empty schemas, duplicate field names, and invalid field types
- reuse existing minimal editor modals
- document update contracts and update the roadmap

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- site update ownership and stable slug
- compatible collection schema update
- incompatible schema rejection with existing content
- invalid collection schema definitions
