### PR TITLE
feat: add bounded public content API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -105,6 +105,21 @@ curl -X GET http://localhost:8080/api/myblog/data
 
 This simple structure makes it easy to consume in frontend applications - you can directly access `response.data.articles` to get all articles, or `response.data.products` for products, etc.
 
+### Paginated public content
+
+For production consumers, prefer the bounded content endpoints over downloading
+the complete site payload:
+
+```text
+GET /api/content/:siteSlug/:collectionSlug?page=1&limit=20
+GET /api/content/:siteSlug/:collectionSlug/:entryId
+```
+
+Collection responses contain `entries` and `pagination`; limits are capped at
+100. Public entries include their opaque `id` alongside flattened field values.
+Responses use `Cache-Control: public, max-age=60, stale-while-revalidate=300`.
+The original `/api/:siteSlug/data` endpoint remains available for compatibility.
+
 ---
 
 ## Media files

--- a/internal/handlers/public_content.go
+++ b/internal/handlers/public_content.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+const publicContentCacheControl = "public, max-age=60, stale-while-revalidate=300"
+
+func (h *Handler) GetPublicEntries(c echo.Context) error {
+	page, err := paginationParameter("page", c.QueryParam("page"), 1, 1, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	limit, err := paginationParameter("limit", c.QueryParam("limit"), 20, 1, 100)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	entries, err := h.Service.GetPublicEntries(c.Param("siteSlug"), c.Param("collectionSlug"), page, limit)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "content not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not load content")
+	}
+	c.Response().Header().Set(echo.HeaderCacheControl, publicContentCacheControl)
+	return c.JSON(http.StatusOK, entries)
+}
+
+func (h *Handler) GetPublicEntry(c echo.Context) error {
+	entry, err := h.Service.GetPublicEntry(c.Param("siteSlug"), c.Param("collectionSlug"), c.Param("entryId"))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "content not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not load content")
+	}
+	c.Response().Header().Set(echo.HeaderCacheControl, publicContentCacheControl)
+	return c.JSON(http.StatusOK, entry)
+}

--- a/internal/handlers/public_content_test.go
+++ b/internal/handlers/public_content_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"barecms/internal/services"
+	"barecms/internal/storage"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func publicContentHandler(t *testing.T) *Handler {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&storage.SiteDB{}, &storage.CollectionDB{}, &storage.EntryDB{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range []any{
+		&storage.SiteDB{ID: "site", Name: "Site", Slug: "site", UserID: "user"},
+		&storage.CollectionDB{ID: "posts", SiteID: "site", Name: "Posts", Slug: "posts"},
+		&storage.EntryDB{ID: "entry", CollectionID: "posts", Data: datatypes.JSON(`{"title":{"value":"Hello","type":"string"}}`)},
+	} {
+		if err := db.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Handler{Service: &services.Service{Storage: &storage.Storage{DB: db}}}
+}
+
+func TestPublicEntriesSetsCachePolicy(t *testing.T) {
+	e := echo.New()
+	handler := publicContentHandler(t)
+	e.GET("/content/:siteSlug/:collectionSlug", handler.GetPublicEntries)
+	response := httptest.NewRecorder()
+	e.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/content/site/posts", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	if response.Header().Get(echo.HeaderCacheControl) != publicContentCacheControl {
+		t.Fatalf("unexpected cache policy: %q", response.Header().Get(echo.HeaderCacheControl))
+	}
+}

--- a/internal/models/entry.go
+++ b/internal/models/entry.go
@@ -28,3 +28,8 @@ type EntryPage struct {
 	Entries    []Entry    `json:"entries"`
 	Pagination Pagination `json:"pagination"`
 }
+
+type PublicEntryPage struct {
+	Entries    []map[string]any `json:"entries"`
+	Pagination Pagination       `json:"pagination"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -41,6 +41,8 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 
 	// Public site data endpoint
 	api.GET("/:siteSlug/data", h.GetSiteData)
+	api.GET("/content/:siteSlug/:collectionSlug", h.GetPublicEntries)
+	api.GET("/content/:siteSlug/:collectionSlug/:entryId", h.GetPublicEntry)
 	api.GET("/files/:fileId", h.GetMedia)
 
 	// Auth routes (public)

--- a/internal/services/public_content.go
+++ b/internal/services/public_content.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"barecms/internal/models"
+	"encoding/json"
+)
+
+func (s *Service) GetPublicEntries(siteSlug, collectionSlug string, page, limit int) (models.PublicEntryPage, error) {
+	collection, err := s.Storage.GetCollectionBySiteAndSlug(siteSlug, collectionSlug)
+	if err != nil {
+		return models.PublicEntryPage{}, err
+	}
+	entriesDB, total, err := s.Storage.GetEntriesPage(collection.ID, limit, (page-1)*limit)
+	if err != nil {
+		return models.PublicEntryPage{}, err
+	}
+	entries := make([]map[string]any, len(entriesDB))
+	for index, entry := range entriesDB {
+		transformed, err := publicEntry(entry.ID, entry.Data)
+		if err != nil {
+			return models.PublicEntryPage{}, err
+		}
+		entries[index] = transformed
+	}
+	totalPages := int((total + int64(limit) - 1) / int64(limit))
+	return models.PublicEntryPage{Entries: entries, Pagination: models.Pagination{Page: page, Limit: limit, Total: total, TotalPages: totalPages}}, nil
+}
+
+func (s *Service) GetPublicEntry(siteSlug, collectionSlug, entryID string) (map[string]any, error) {
+	collection, err := s.Storage.GetCollectionBySiteAndSlug(siteSlug, collectionSlug)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := s.Storage.GetEntryInCollection(entryID, collection.ID)
+	if err != nil {
+		return nil, err
+	}
+	return publicEntry(entry.ID, entry.Data)
+}
+
+func publicEntry(id string, data []byte) (map[string]any, error) {
+	var entryData map[string]any
+	if err := json.Unmarshal(data, &entryData); err != nil {
+		return nil, err
+	}
+	transformed, err := transformEntryData(entryData)
+	if err != nil {
+		return nil, err
+	}
+	transformed["id"] = id
+	return transformed, nil
+}

--- a/internal/services/public_content_test.go
+++ b/internal/services/public_content_test.go
@@ -1,0 +1,31 @@
+package services
+
+import "testing"
+
+func TestPublicContentIsPaginatedAndFlattened(t *testing.T) {
+	service := entryTestService(t)
+	page, err := service.GetPublicEntries("site", "posts", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Entries) != 1 || page.Pagination.Total != 1 || page.Pagination.TotalPages != 1 {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+	if page.Entries[0]["id"] != "entry-1" || page.Entries[0]["title"] != "Old" {
+		t.Fatalf("unexpected public entry: %+v", page.Entries[0])
+	}
+}
+
+func TestPublicEntryIsScopedToSiteAndCollection(t *testing.T) {
+	service := entryTestService(t)
+	entry, err := service.GetPublicEntry("site", "posts", "entry-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry["id"] != "entry-1" {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+	if _, err := service.GetPublicEntry("site", "missing", "entry-1"); err == nil {
+		t.Fatal("expected missing collection to be rejected")
+	}
+}

--- a/internal/storage/collections.go
+++ b/internal/storage/collections.go
@@ -28,6 +28,15 @@ func (s *Storage) GetCollection(id string) (CollectionDB, error) {
 	return collection, nil
 }
 
+func (s *Storage) GetCollectionBySiteAndSlug(siteSlug, collectionSlug string) (CollectionDB, error) {
+	var collection CollectionDB
+	err := s.DB.Table("collections").Select("collections.*").
+		Joins("JOIN sites ON sites.id = collections.site_id").
+		Where("sites.slug = ? AND collections.slug = ?", siteSlug, collectionSlug).
+		First(&collection).Error
+	return collection, err
+}
+
 func (s *Storage) UpdateCollection(id, name string, fields datatypes.JSON) error {
 	return s.DB.Model(&CollectionDB{}).Where("id = ?", id).Updates(map[string]any{"name": name, "fields": fields}).Error
 }

--- a/internal/storage/entries.go
+++ b/internal/storage/entries.go
@@ -17,6 +17,12 @@ func (s *Storage) GetEntryByID(id string) (EntryDB, error) {
 	return entry, nil
 }
 
+func (s *Storage) GetEntryInCollection(id, collectionID string) (EntryDB, error) {
+	var entry EntryDB
+	err := s.DB.Where("id = ? AND collection_id = ?", id, collectionID).First(&entry).Error
+	return entry, err
+}
+
 func (s *Storage) GetEntriesByCollectionID(collectionID string) ([]EntryDB, error) {
 	var entries []EntryDB
 	err := s.DB.Find(&entries, "collection_id = ?", collectionID).Error

--- a/roadmap.md
+++ b/roadmap.md
@@ -49,6 +49,8 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - Lock response shapes for sites, collections, entries
   - [x] Bounded pagination and metadata for collection entries (`feature/api-pagination`)
   - [ ] Pagination on remaining authenticated list endpoints
+  - [x] Bounded public collection and single-entry endpoints with cache policy (`feature/public-content-api`)
+  - [x] Preserve legacy whole-site endpoint compatibility
 - [ ] **Database integrity and migrations**
   - [x] Transactional site, collection, and account deletion (`reliability/database-integrity`)
   - [x] Cascade media metadata cleanup with best-effort disk cleanup


### PR DESCRIPTION
## Summary

- add a bounded public collection endpoint
- add public single-entry retrieval by opaque ID
- return flattened fields plus stable entry IDs
- default pages to 20 entries and cap limits at 100
- scope entries through both site and collection slugs
- add a public cache policy with stale-while-revalidate
- preserve the existing whole-site endpoint unchanged
- document the preferred production API

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- public pagination and flattened response shape
- entry site/collection scoping
- HTTP cache-control behavior
