### PR TITLE
docs: harden self-hosting quick start

### DIFF
--- a/deploy/.env.template
+++ b/deploy/.env.template
@@ -1,7 +1,12 @@
-JWT_SECRET=gen_jwt_secret
+JWT_SECRET=change_jwt_secret
 POSTGRES_USER=barecms_user
-POSTGRES_PASSWORD=barecms_password
+POSTGRES_PASSWORD=change_database_password
 POSTGRES_DB=barecms_db
-DATABASE_URL=postgresql://barecms_user:barecms_password@postgres:5432/barecms_db
+DATABASE_URL=postgresql://barecms_user:change_database_password@postgres:5432/barecms_db
 PORT=8080
-ENV=prod
+ENV=production
+DEBUG=false
+MAX_REQUEST_BODY=12M
+AUTH_RATE_LIMIT_PER_MINUTE=10
+UPLOADS_DIR=/app/uploads
+MAX_FILE_SIZE=10485760

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,21 +12,37 @@ Production-ready deployment configuration for BareCMS.
 ```bash
 mkdir barecms-app && cd barecms-app
 
-curl -sSL https://raw.githubusercontent.com/snowztech/barecms/main/deploy/.env.template | \
-  sed "s/gen_jwt_secret/$(openssl rand -base64 32)/" > .env
+curl -sSLo .env https://raw.githubusercontent.com/snowztech/barecms/main/deploy/.env.template
 
 curl -o docker-compose.yml \
   https://raw.githubusercontent.com/snowztech/barecms/main/deploy/docker-compose.yml
 
+JWT_SECRET=$(openssl rand -hex 32)
+DB_PASSWORD=$(openssl rand -hex 24)
+sed -i "s/change_jwt_secret/$JWT_SECRET/" .env
+sed -i "s/change_database_password/$DB_PASSWORD/g" .env
+
 docker compose up -d
+docker compose ps
+curl --fail http://localhost:8080/readyz
 ```
 
 ## Environment Variables
 
-Edit `.env` to customize:
-- `POSTGRES_PASSWORD` - Change from default
-- `DATABASE_URL` - Update if using external database
-- `PORT` - Change application port
+| Variable | Purpose |
+|---|---|
+| `JWT_SECRET` | Token-signing secret; use at least 32 random characters |
+| `POSTGRES_USER` | PostgreSQL user created by the database container |
+| `POSTGRES_PASSWORD` | PostgreSQL password; must match `DATABASE_URL` |
+| `POSTGRES_DB` | PostgreSQL database name |
+| `DATABASE_URL` | Complete PostgreSQL connection string |
+| `PORT` | Host port published for BareCMS |
+| `ENV` | Use `production` to enable production validation and HSTS |
+| `DEBUG` | Application debug flag; keep `false` in production |
+| `AUTH_RATE_LIMIT_PER_MINUTE` | Per-IP login and registration burst/refill limit |
+| `MAX_FILE_SIZE` | Maximum individual upload size in bytes |
+| `MAX_REQUEST_BODY` | Global body limit; must exceed `MAX_FILE_SIZE` for multipart overhead |
+| `UPLOADS_DIR` | Media path inside the container; keep `/app/uploads` with this Compose file |
 
 ## Management
 
@@ -39,6 +55,18 @@ docker compose logs -f barecms
 
 # Backup database
 docker compose exec postgres pg_dump -U barecms_user barecms_db > backup.sql
+
+# Backup uploaded media
+docker compose exec -T barecms tar -czf - -C /app uploads > uploads.tar.gz
+
+# Restore database into an empty database
+docker compose exec -T postgres psql -U barecms_user barecms_db < backup.sql
+
+# Restore uploaded media
+docker compose exec -T barecms tar -xzf - -C /app < uploads.tar.gz
 ```
+
+Back up both PostgreSQL and uploads. Verify backups periodically by restoring
+them into a separate test deployment and checking `/readyz` plus public media.
 
 For full documentation, see the [main README](../README.md).

--- a/roadmap.md
+++ b/roadmap.md
@@ -62,13 +62,14 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - Bug-free CRUD for every model
   - Loading, empty, and error states
   - Confirm dialogs on destructive actions
-- [ ] **Docker docs**
-  - Document every environment variable
-  - Provide `.env.production` example
+- [x] **Docker and self-hosting**
+  - [x] Document production environment variables
+  - [x] Provide a production environment template
   - [x] Add liveness `/healthz`, database readiness `/readyz`, and container health check (`reliability/health-readiness`)
   - [x] Fail startup when database initialization fails
   - [x] Reproducible multi-stage build, static binary, pinned runtime, and non-root container (`reliability/container-hardening`)
   - [x] Production frontend dependency audit enforced in CI
+  - [x] Document database and media backup/restore verification (`docs/self-hosting-polish`)
 
 ## Phase 2. MCP-native pivot
 


### PR DESCRIPTION
## Summary

- replace predictable deployment credentials with generated JWT and database secrets
- avoid fragile Base64 substitution in the quick-start script
- provide a complete production environment template
- document every production environment variable
- verify readiness after first startup
- document database and media backup and restore commands
- require periodic restore verification
- complete the self-hosting roadmap milestone

## Validation

- shell substitutions use hex-only generated values
- production configuration enables strict secret validation
- upload and database persistence settings match the provided Compose file
