### PR TITLE
feat: show field-level validation errors

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -44,7 +44,7 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
   - [x] Required, schema, primitive type, URL, and date checks for entries (`feature/entry-validation`)
   - [x] Field-level `422 validation_failed` response shape
   - [ ] Length and numeric range constraints in collection schemas
-  - Frontend renders field-level errors
+  - [x] Frontend renders accessible field-level errors (`feature/field-validation-ui`)
 - [ ] **API stability**
   - Lock response shapes for sites, collections, entries
   - [x] Bounded pagination and metadata for collection entries (`feature/api-pagination`)

--- a/ui/src/components/MediaPicker.tsx
+++ b/ui/src/components/MediaPicker.tsx
@@ -7,6 +7,8 @@ interface MediaPickerProps {
   value: string;
   onChange: (url: string) => void;
   required?: boolean;
+  invalid?: boolean;
+  ariaDescribedBy?: string;
 }
 
 const MediaPicker: React.FC<MediaPickerProps> = ({
@@ -14,6 +16,8 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
   value,
   onChange,
   required,
+  invalid,
+  ariaDescribedBy,
 }) => {
   const [files, setFiles] = useState<MediaFile[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -114,7 +118,14 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
         </div>
       )}
 
-      <input type="hidden" value={value} required={required} readOnly />
+      <input
+        type="hidden"
+        value={value}
+        required={required}
+        readOnly
+        aria-invalid={invalid}
+        aria-describedby={ariaDescribedBy}
+      />
     </div>
   );
 };

--- a/ui/src/components/modals/CreateCollectionModal.tsx
+++ b/ui/src/components/modals/CreateCollectionModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useApi } from "@/hooks/useApi";
+import { ApiRequestError, useApi } from "@/hooks/useApi";
 import { Field, FieldType, VALID_FIELD_TYPES } from "@/types/fields";
 
 interface CreateCollectionModalProps {
@@ -24,6 +24,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   const [newFieldOptional, setNewFieldOptional] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null);
   const [fieldsError, setFieldsError] = useState<string | null>(null);
+  const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
   const { request, loading } = useApi();
 
   useEffect(() => {
@@ -36,6 +37,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   ) => {
     setCollectionName(e.target.value);
     setError(null);
+    setServerErrors((current) => ({ ...current, name: "" }));
   };
 
   const handleNewFieldNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -86,16 +88,19 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     event.preventDefault();
     if (collectionName.trim() === "") {
       setError("Collection name cannot be empty.");
+      setServerErrors({ name: "is required" });
       return;
     }
 
     if (fields.length === 0) {
       setFieldsError("You must add at least one field to the collection.");
+      setServerErrors({ fields: "must contain at least one field" });
       return;
     }
 
     setError(null);
     setFieldsError(null);
+    setServerErrors({});
     try {
       await request({
         url: collectionId ? `/collections/${collectionId}` : "/collections",
@@ -111,9 +116,9 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       setTimeout(() => {
         window.location.reload();
       }, 300);
-    } catch (e: any) {
-      console.error(e);
-      setError(e.message || "Failed to create collection. Please try again.");
+    } catch (e: unknown) {
+      if (e instanceof ApiRequestError) setServerErrors(e.fields);
+      setError(e instanceof Error ? e.message : "Failed to save collection.");
     } finally {
       if (!collectionId) {
         setCollectionName("");
@@ -129,10 +134,13 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
         <input
           type="text"
           placeholder="Enter collection name"
-          className="input input-bordered w-full"
+          className={`input input-bordered w-full ${serverErrors.name ? "input-error" : ""}`}
           value={collectionName}
           onChange={handleCollectionNameChange}
+          aria-invalid={Boolean(serverErrors.name)}
+          aria-describedby={serverErrors.name ? "collection-name-error" : undefined}
         />
+        {serverErrors.name && <p id="collection-name-error" role="alert" className="text-sm text-error mt-1">{serverErrors.name}</p>}
         {error && <p className="text-red-500 mt-2">{error}</p>}
         <div className="mt-4">
           <h4 className="font-semibold mb-2">Fields</h4>
@@ -141,6 +149,11 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
               <p className="mr-2">
                 {field.name} ({field.type}{field.optional && ', optional'})
               </p>
+              {(serverErrors[`fields.${index}.name`] || serverErrors[`fields.${index}.type`]) && (
+                <p role="alert" className="text-sm text-error mr-2">
+                  {serverErrors[`fields.${index}.name`] || serverErrors[`fields.${index}.type`]}
+                </p>
+              )}
               <button
                 className="btn btn-sm btn-error btn-outline"
                 onClick={() => removeField(index)}
@@ -184,6 +197,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
           </label>
         </div>
         {fieldsError && <p className="text-red-500 mt-2">{fieldsError}</p>}
+        {serverErrors.fields && <p role="alert" className="text-sm text-error mt-2">{serverErrors.fields}</p>}
         <div className="modal-action">
           <button
             disabled={loading}

--- a/ui/src/components/modals/CreateEntryModal.tsx
+++ b/ui/src/components/modals/CreateEntryModal.tsx
@@ -1,6 +1,6 @@
 import { Field, FieldType } from "@/types/fields";
 import { useEffect, useState } from "react";
-import { useApi } from "@/hooks/useApi";
+import { ApiRequestError, useApi } from "@/hooks/useApi";
 import MediaPicker from "@/components/MediaPicker";
 
 interface CreateEntryModalProps {
@@ -22,6 +22,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
 }) => {
   const [formState, setFormState] = useState<Record<string, any>>({});
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const { request, loading } = useApi();
 
   const closeDialog = () => {
@@ -50,6 +51,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
   ) => {
     const { name, value } = e.target;
     setFormState((prevState) => ({ ...prevState, [name]: value }));
+    setFieldErrors((current) => ({ ...current, [name]: "" }));
   };
 
   const handleSubmit = async () => {
@@ -58,11 +60,13 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
     );
 
     if (hasRequiredFields) {
-      setError("All fields are required.");
+      setFieldErrors(Object.fromEntries(fields.filter((field) => !field.optional && !formState[field.name]).map((field) => [field.name, "is required"])));
+      setError("Please correct the highlighted fields.");
       return;
     }
 
     setError(null);
+    setFieldErrors({});
     try {
       // Prepare data with types
       const dataWithTypes = fields.reduce(
@@ -88,11 +92,16 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
       setTimeout(() => {
         window.location.reload();
       }, 300);
-    } catch (e: any) {
-      console.error(e);
-      setError(e.message || "Failed to create entry. Please try again.");
+    } catch (e: unknown) {
+      if (e instanceof ApiRequestError) setFieldErrors(e.fields);
+      setError(e instanceof Error ? e.message : "Failed to save entry.");
     }
   };
+
+  const accessibilityProps = (field: Field) => ({
+    "aria-invalid": Boolean(fieldErrors[field.name]),
+    "aria-describedby": fieldErrors[field.name] ? `${field.name}-error` : undefined,
+  });
 
   const renderFieldInput = (field: Field) => {
     switch (field.type) {
@@ -106,6 +115,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
       case FieldType.STRING:
@@ -118,6 +128,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
       case FieldType.TEXT:
@@ -129,6 +140,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="textarea textarea-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
       case FieldType.NUMBER:
@@ -141,6 +153,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
       case FieldType.BOOLEAN:
@@ -152,6 +165,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="select select-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           >
             <option disabled>
               Select an option
@@ -170,6 +184,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
       case FieldType.IMAGE:
@@ -177,10 +192,13 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
           <MediaPicker
             siteId={siteId}
             value={formState[field.name]}
-            onChange={(url) =>
-              setFormState((previous) => ({ ...previous, [field.name]: url }))
-            }
+            onChange={(url) => {
+              setFormState((previous) => ({ ...previous, [field.name]: url }));
+              setFieldErrors((current) => ({ ...current, [field.name]: "" }));
+            }}
             required={!field.optional}
+            invalid={Boolean(fieldErrors[field.name])}
+            ariaDescribedBy={fieldErrors[field.name] ? `${field.name}-error` : undefined}
           />
         );
       default:
@@ -193,6 +211,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            {...accessibilityProps(field)}
           />
         );
     }
@@ -205,7 +224,10 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
         {error && <p className="text-red-500 mb-4">{error}</p>}
         <div className="mt-4">
           {fields.map((field) => (
-            <div key={field.name} className="mb-4">
+            <div
+              key={field.name}
+              className={`mb-4 rounded ${fieldErrors[field.name] ? "ring-1 ring-error p-2" : ""}`}
+            >
               <label
                 className="block text-sm font-medium text-gray-700 mb-2"
                 htmlFor={field.name}
@@ -213,6 +235,11 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
                 {field.name} ({field.type}{field.optional && ', optional'})
               </label>
               {renderFieldInput(field)}
+              {fieldErrors[field.name] && (
+                <p id={`${field.name}-error`} role="alert" className="text-sm text-error mt-1">
+                  {fieldErrors[field.name]}
+                </p>
+              )}
             </div>
           ))}
         </div>

--- a/ui/src/components/modals/CreateSiteModal.tsx
+++ b/ui/src/components/modals/CreateSiteModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useApi } from "@/hooks/useApi";
+import { ApiRequestError, useApi } from "@/hooks/useApi";
 
 interface CreateSiteModalProps {
   userId?: string;
@@ -16,11 +16,13 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
 }) => {
   const [siteName, setSiteName] = useState(initialName);
   const [error, setError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
   const { request, loading } = useApi();
 
   const handleSiteNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSiteName(e.target.value);
     setError(null);
+    setNameError(null);
   };
 
   const closeDialog = () => {
@@ -33,6 +35,7 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
     event.preventDefault();
     if (siteName.trim() === "") {
       setError("Site name cannot be empty.");
+      setNameError("is required");
       return;
     }
 
@@ -47,9 +50,9 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
       setTimeout(() => {
         window.location.reload();
       }, 300);
-    } catch (e: any) {
-      console.error(e);
-      setError(e.message || "Failed to create site. Please try again.");
+    } catch (e: unknown) {
+      if (e instanceof ApiRequestError) setNameError(e.fields.name || null);
+      setError(e instanceof Error ? e.message : "Failed to save site.");
     } finally {
       if (!siteId) setSiteName("");
     }
@@ -62,10 +65,13 @@ const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
         <input
           type="text"
           placeholder="Enter site name"
-          className="input input-bordered w-full"
+          className={`input input-bordered w-full ${nameError ? "input-error" : ""}`}
           value={siteName}
           onChange={handleSiteNameChange}
+          aria-invalid={Boolean(nameError)}
+          aria-describedby={nameError ? "site-name-error" : undefined}
         />
+        {nameError && <p id="site-name-error" role="alert" className="text-sm text-error mt-1">{nameError}</p>}
         {error && <p className="text-red-500 mt-2">{error}</p>}
         <div className="modal-action">
           <button

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -2,6 +2,16 @@ import { useCallback, useState } from "react";
 import apiClient from "@/lib/api";
 import { AxiosRequestConfig } from "axios";
 
+export class ApiRequestError extends Error {
+  fields: Record<string, string>;
+
+  constructor(message: string, fields: Record<string, string> = {}) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.fields = fields;
+  }
+}
+
 export const useApi = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +30,7 @@ export const useApi = () => {
         err.response?.data?.message ||
         err.message;
       setError(errorMessage);
-      throw new Error(errorMessage);
+      throw new ApiRequestError(errorMessage, apiError?.fields || {});
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

- preserve structured field maps in frontend API errors
- render server validation messages beside affected controls
- add accessible error descriptions and invalid-state attributes
- add visible invalid-field styling
- clear individual errors as users correct values
- cover site, collection schema, entry, and media fields
- update the live roadmap

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `go test ./...`
- `go vet ./...`
- `git diff --check`
