### PR TITLE
feat: add schema field constraints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -181,6 +181,14 @@ intentionally stable so renaming a site does not break consumers.
 schema. Collection slugs remain stable. Schema changes are rejected with a
 `422 validation_failed` response if any existing entry would become invalid.
 
+Collection fields may define optional constraints:
+
+- `minLength` and `maxLength` for `string`, `text`, and `url` fields.
+- `min` and `max` for `number` fields.
+
+Constraints are validated when schemas are created or edited and enforced for
+all subsequent entry creation and updates.
+
 ## 🔐 Authentication Endpoints
 
 ### Register User

--- a/internal/models/field_types.go
+++ b/internal/models/field_types.go
@@ -34,7 +34,11 @@ func IsValidFieldType(fieldType string) bool {
 }
 
 type Field struct {
-	Name     string    `json:"name"`
-	Type     FieldType `json:"type"`
-	Optional bool      `json:"optional,omitempty"`
+	Name      string    `json:"name"`
+	Type      FieldType `json:"type"`
+	Optional  bool      `json:"optional,omitempty"`
+	MinLength *int      `json:"minLength,omitempty"`
+	MaxLength *int      `json:"maxLength,omitempty"`
+	Min       *float64  `json:"min,omitempty"`
+	Max       *float64  `json:"max,omitempty"`
 }

--- a/internal/services/validation.go
+++ b/internal/services/validation.go
@@ -4,6 +4,7 @@ import (
 	"barecms/internal/models"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"strconv"
 	"strings"
@@ -41,7 +42,7 @@ func validateEntryData(data json.RawMessage, fields []models.Field) error {
 			errors[field.Name] = "type does not match collection schema"
 			continue
 		}
-		if message := validateFieldValue(field.Type, value.Value); message != "" {
+		if message := validateFieldValue(field, value.Value); message != "" {
 			errors[field.Name] = message
 		}
 	}
@@ -56,15 +57,22 @@ func validateEntryData(data json.RawMessage, fields []models.Field) error {
 	return nil
 }
 
-func validateFieldValue(fieldType models.FieldType, value any) string {
+func validateFieldValue(field models.Field, value any) string {
 	text, ok := value.(string)
 	if !ok {
 		return "must be a string value"
 	}
-	switch fieldType {
+	switch field.Type {
 	case models.FieldTypeNumber:
-		if _, err := strconv.ParseFloat(text, 64); err != nil {
+		number, err := strconv.ParseFloat(text, 64)
+		if err != nil || math.IsNaN(number) || math.IsInf(number, 0) {
 			return "must be a number"
+		}
+		if field.Min != nil && number < *field.Min {
+			return fmt.Sprintf("must be at least %g", *field.Min)
+		}
+		if field.Max != nil && number > *field.Max {
+			return fmt.Sprintf("must be at most %g", *field.Max)
 		}
 	case models.FieldTypeBoolean:
 		if _, err := strconv.ParseBool(text); err != nil {
@@ -79,6 +87,12 @@ func validateFieldValue(fieldType models.FieldType, value any) string {
 		if err != nil || (parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https") {
 			return "must be a valid URL"
 		}
+	}
+	if field.MinLength != nil && len([]rune(text)) < *field.MinLength {
+		return fmt.Sprintf("must contain at least %d characters", *field.MinLength)
+	}
+	if field.MaxLength != nil && len([]rune(text)) > *field.MaxLength {
+		return fmt.Sprintf("must contain at most %d characters", *field.MaxLength)
 	}
 	return ""
 }
@@ -103,6 +117,25 @@ func validateCollectionSchema(name string, fields []models.Field) error {
 		seen[fieldName] = true
 		if !models.IsValidFieldType(string(field.Type)) {
 			problems[key+".type"] = "is invalid"
+		}
+		stringLike := field.Type == models.FieldTypeString || field.Type == models.FieldTypeText || field.Type == models.FieldTypeURL
+		if (field.MinLength != nil || field.MaxLength != nil) && !stringLike {
+			problems[key+".length"] = "is only supported for string, text, and URL fields"
+		}
+		if field.MinLength != nil && *field.MinLength < 0 {
+			problems[key+".minLength"] = "must be zero or greater"
+		}
+		if field.MaxLength != nil && *field.MaxLength < 0 {
+			problems[key+".maxLength"] = "must be zero or greater"
+		}
+		if field.MinLength != nil && field.MaxLength != nil && *field.MinLength > *field.MaxLength {
+			problems[key+".maxLength"] = "must be greater than or equal to minLength"
+		}
+		if (field.Min != nil || field.Max != nil) && field.Type != models.FieldTypeNumber {
+			problems[key+".range"] = "is only supported for number fields"
+		}
+		if field.Min != nil && field.Max != nil && *field.Min > *field.Max {
+			problems[key+".max"] = "must be greater than or equal to min"
 		}
 	}
 	if len(problems) > 0 {

--- a/internal/services/validation_test.go
+++ b/internal/services/validation_test.go
@@ -48,3 +48,40 @@ func TestValidateCollectionSchemaRejectsInvalidDefinitions(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateEntryDataEnforcesLengthAndRangeConstraints(t *testing.T) {
+	minLength, maxLength := 3, 5
+	min, max := 1.0, 10.0
+	fields := []models.Field{
+		{Name: "title", Type: models.FieldTypeString, MinLength: &minLength, MaxLength: &maxLength},
+		{Name: "rating", Type: models.FieldTypeNumber, Min: &min, Max: &max},
+	}
+	invalid := json.RawMessage(`{"title":{"value":"ab","type":"string"},"rating":{"value":"11","type":"number"}}`)
+	var validationError *ValidationError
+	if !errors.As(validateEntryData(invalid, fields), &validationError) {
+		t.Fatal("expected constraint validation error")
+	}
+	if validationError.Fields["title"] == "" || validationError.Fields["rating"] == "" {
+		t.Fatalf("missing constraint errors: %+v", validationError.Fields)
+	}
+	valid := json.RawMessage(`{"title":{"value":"hello","type":"string"},"rating":{"value":"10","type":"number"}}`)
+	if err := validateEntryData(valid, fields); err != nil {
+		t.Fatalf("valid constrained entry rejected: %v", err)
+	}
+}
+
+func TestValidateCollectionSchemaRejectsInvalidConstraints(t *testing.T) {
+	minLength, maxLength := 5, 2
+	min, max := 10.0, 1.0
+	err := validateCollectionSchema("Posts", []models.Field{
+		{Name: "title", Type: models.FieldTypeString, MinLength: &minLength, MaxLength: &maxLength},
+		{Name: "rating", Type: models.FieldTypeNumber, Min: &min, Max: &max},
+	})
+	var validationError *ValidationError
+	if !errors.As(err, &validationError) {
+		t.Fatal("expected invalid constraints to be rejected")
+	}
+	if validationError.Fields["fields.0.maxLength"] == "" || validationError.Fields["fields.1.max"] == "" {
+		t.Fatalf("missing schema errors: %+v", validationError.Fields)
+	}
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -43,7 +43,7 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [ ] **Input validation and structured error responses**
   - [x] Required, schema, primitive type, URL, and date checks for entries (`feature/entry-validation`)
   - [x] Field-level `422 validation_failed` response shape
-  - [ ] Length and numeric range constraints in collection schemas
+  - [x] Length and numeric range constraints in collection schemas (`feature/schema-constraints`)
   - [x] Frontend renders accessible field-level errors (`feature/field-validation-ui`)
 - [ ] **API stability**
   - Lock response shapes for sites, collections, entries

--- a/ui/src/components/modals/CreateCollectionModal.tsx
+++ b/ui/src/components/modals/CreateCollectionModal.tsx
@@ -22,6 +22,10 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldType, setNewFieldType] = useState<FieldType>(FieldType.STRING);
   const [newFieldOptional, setNewFieldOptional] = useState<boolean>(false)
+  const [newMinLength, setNewMinLength] = useState("");
+  const [newMaxLength, setNewMaxLength] = useState("");
+  const [newMin, setNewMin] = useState("");
+  const [newMax, setNewMax] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [fieldsError, setFieldsError] = useState<string | null>(null);
   const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
@@ -48,6 +52,14 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     setNewFieldOptional(e.target.checked)
   }
 
+  const handleNewFieldTypeChange = (type: FieldType) => {
+    setNewFieldType(type);
+    setNewMinLength("");
+    setNewMaxLength("");
+    setNewMin("");
+    setNewMax("");
+  };
+
   const addField = () => {
     if (newFieldName.trim() === "") {
       setFieldsError("Field name cannot be empty.");
@@ -66,12 +78,20 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       {
         name: newFieldName.trim().toLowerCase(),
         type: newFieldType,
-        optional: newFieldOptional
+        optional: newFieldOptional,
+        minLength: newMinLength === "" ? undefined : Number(newMinLength),
+        maxLength: newMaxLength === "" ? undefined : Number(newMaxLength),
+        min: newMin === "" ? undefined : Number(newMin),
+        max: newMax === "" ? undefined : Number(newMax),
       },
     ]);
     setNewFieldName("");
     setNewFieldType(FieldType.STRING);
     setNewFieldOptional(false);
+    setNewMinLength("");
+    setNewMaxLength("");
+    setNewMin("");
+    setNewMax("");
   };
 
   const removeField = (index: number) => {
@@ -148,6 +168,10 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
             <div key={index} className="flex items-center mb-2">
               <p className="mr-2">
                 {field.name} ({field.type}{field.optional && ', optional'})
+                {field.minLength !== undefined && ` · min ${field.minLength} chars`}
+                {field.maxLength !== undefined && ` · max ${field.maxLength} chars`}
+                {field.min !== undefined && ` · min ${field.min}`}
+                {field.max !== undefined && ` · max ${field.max}`}
               </p>
               {(serverErrors[`fields.${index}.name`] || serverErrors[`fields.${index}.type`]) && (
                 <p role="alert" className="text-sm text-error mr-2">
@@ -173,7 +197,7 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
             <select
               className="select select-bordered"
               value={newFieldType}
-              onChange={(e) => setNewFieldType(e.target.value as FieldType)}
+              onChange={(e) => handleNewFieldTypeChange(e.target.value as FieldType)}
             >
               {VALID_FIELD_TYPES.map((type: FieldType) => (
                 <option key={type} value={type}>
@@ -195,6 +219,18 @@ const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
             />
             Optional
           </label>
+          {[FieldType.STRING, FieldType.TEXT, FieldType.URL].includes(newFieldType) && (
+            <div className="grid grid-cols-2 gap-2 mb-2">
+              <input type="number" min="0" className="input input-bordered" placeholder="Min length" value={newMinLength} onChange={(event) => setNewMinLength(event.target.value)} />
+              <input type="number" min="0" className="input input-bordered" placeholder="Max length" value={newMaxLength} onChange={(event) => setNewMaxLength(event.target.value)} />
+            </div>
+          )}
+          {newFieldType === FieldType.NUMBER && (
+            <div className="grid grid-cols-2 gap-2 mb-2">
+              <input type="number" className="input input-bordered" placeholder="Minimum" value={newMin} onChange={(event) => setNewMin(event.target.value)} />
+              <input type="number" className="input input-bordered" placeholder="Maximum" value={newMax} onChange={(event) => setNewMax(event.target.value)} />
+            </div>
+          )}
         </div>
         {fieldsError && <p className="text-red-500 mt-2">{fieldsError}</p>}
         {serverErrors.fields && <p role="alert" className="text-sm text-error mt-2">{serverErrors.fields}</p>}

--- a/ui/src/components/modals/CreateEntryModal.tsx
+++ b/ui/src/components/modals/CreateEntryModal.tsx
@@ -115,6 +115,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            minLength={field.minLength}
+            maxLength={field.maxLength}
             {...accessibilityProps(field)}
           />
         );
@@ -128,6 +130,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            minLength={field.minLength}
+            maxLength={field.maxLength}
             {...accessibilityProps(field)}
           />
         );
@@ -140,6 +144,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="textarea textarea-bordered w-full"
             required={!field.optional}
+            minLength={field.minLength}
+            maxLength={field.maxLength}
             {...accessibilityProps(field)}
           />
         );
@@ -153,6 +159,8 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({
             onChange={handleInputChange}
             className="input input-bordered w-full"
             required={!field.optional}
+            min={field.min}
+            max={field.max}
             {...accessibilityProps(field)}
           />
         );

--- a/ui/src/types/fields.ts
+++ b/ui/src/types/fields.ts
@@ -16,4 +16,8 @@ export interface Field {
   name: string;
   type: FieldType;
   optional?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  min?: number;
+  max?: number;
 }


### PR DESCRIPTION
## Summary

- add optional minLength and maxLength constraints for string, text, and URL fields
- add optional min and max constraints for number fields
- validate constraint applicability and ordering in collection schemas
- enforce constraints during entry creation and editing
- revalidate existing content before constrained schema updates
- reject NaN and infinite numeric values
- expose minimal constraint controls in the collection editor
- apply native browser constraints in entry forms
- document the schema contract and complete the validation roadmap item

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- valid and invalid length boundaries
- valid and invalid numeric ranges
- invalid constraint definitions
