### PR TITLE
feat: paginate authenticated resource lists

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,10 @@ collection schema before it replaces the existing entry data.
 
 `page` starts at 1 and `limit` is capped at 100.
 
+Authenticated site, collection, and media lists use the same `page`/`limit`
+parameters and `{ resource, pagination }` envelope. Site and collection lists
+default to 20 items; media defaults to 50. All limits are capped at 100.
+
 ### Update a site
 
 `PUT /api/sites/:siteId` accepts `{ "name": "New name" }`. The public slug is

--- a/internal/handlers/collections.go
+++ b/internal/handlers/collections.go
@@ -35,13 +35,20 @@ func (h *Handler) GetCollection(c echo.Context) error {
 
 func (h *Handler) GetCollectionsBySiteID(c echo.Context) error {
 	siteID := c.Param("id")
-
-	collections, err := h.Service.GetCollectionsBySiteID(siteID, currentUserID(c))
+	page, err := paginationParameter("page", c.QueryParam("page"), 1, 1, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	limit, err := paginationParameter("limit", c.QueryParam("limit"), 20, 1, 100)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	collections, err := h.Service.GetCollectionsPage(siteID, currentUserID(c), page, limit)
 	if err != nil {
 		return serviceError(err)
 	}
 
-	return c.JSON(http.StatusOK, map[string]interface{}{"collections": collections})
+	return c.JSON(http.StatusOK, collections)
 }
 
 func (h *Handler) DeleteCollection(c echo.Context) error {

--- a/internal/handlers/media.go
+++ b/internal/handlers/media.go
@@ -35,11 +35,19 @@ func (h *Handler) UploadMedia(c echo.Context) error {
 }
 
 func (h *Handler) ListMedia(c echo.Context) error {
-	files, err := h.Service.ListMedia(c.Param("siteId"), currentUserID(c))
+	page, err := paginationParameter("page", c.QueryParam("page"), 1, 1, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	limit, err := paginationParameter("limit", c.QueryParam("limit"), 50, 1, 100)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	files, err := h.Service.ListMediaPage(c.Param("siteId"), currentUserID(c), page, limit)
 	if err != nil {
 		return serviceError(err)
 	}
-	return c.JSON(http.StatusOK, map[string]any{"files": files})
+	return c.JSON(http.StatusOK, files)
 }
 
 func (h *Handler) GetMedia(c echo.Context) error {

--- a/internal/handlers/sites.go
+++ b/internal/handlers/sites.go
@@ -8,12 +8,20 @@ import (
 )
 
 func (h *Handler) GetSites(c echo.Context) error {
-	sites, err := h.Service.GetSites(currentUserID(c))
+	page, err := paginationParameter("page", c.QueryParam("page"), 1, 1, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	limit, err := paginationParameter("limit", c.QueryParam("limit"), 20, 1, 100)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	sites, err := h.Service.GetSitesPage(currentUserID(c), page, limit)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	return c.JSON(http.StatusOK, map[string][]models.Site{"sites": sites})
+	return c.JSON(http.StatusOK, sites)
 }
 
 func (h *Handler) GetSite(c echo.Context) error {

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -19,3 +19,8 @@ type UpdateCollectionRequest struct {
 	Name   string  `json:"name"`
 	Fields []Field `json:"fields"`
 }
+
+type CollectionPage struct {
+	Collections []Collection `json:"collections"`
+	Pagination  Pagination   `json:"pagination"`
+}

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -11,3 +11,8 @@ type MediaFile struct {
 	URL          string    `json:"url"`
 	CreatedAt    time.Time `json:"createdAt"`
 }
+
+type MediaFilePage struct {
+	Files      []MediaFile `json:"files"`
+	Pagination Pagination  `json:"pagination"`
+}

--- a/internal/models/site.go
+++ b/internal/models/site.go
@@ -22,3 +22,8 @@ type SiteData struct {
 	Slug string                 `json:"slug"`
 	Data map[string]interface{} `json:"data"`
 }
+
+type SitePage struct {
+	Sites      []Site     `json:"sites"`
+	Pagination Pagination `json:"pagination"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -67,7 +67,7 @@ func Setup(service *services.Service, config configs.AppConfig) *echo.Echo {
 	// Sites routes
 	protected.GET("/sites", h.GetSites)
 	protected.GET("/sites/:id", h.GetSite)
-	protected.GET("/sites/:id/collections", h.GetSiteWithCollections)
+	protected.GET("/sites/:id/collections", h.GetCollectionsBySiteID)
 	protected.POST("/sites", h.CreateSite)
 	protected.PUT("/sites/:id", h.UpdateSite)
 	protected.DELETE("/sites/:id", h.DeleteSite)

--- a/internal/services/collections.go
+++ b/internal/services/collections.go
@@ -91,6 +91,21 @@ func (s *Service) GetCollectionsBySiteID(siteID, userID string) ([]models.Collec
 
 }
 
+func (s *Service) GetCollectionsPage(siteID, userID string, page, limit int) (models.CollectionPage, error) {
+	if err := s.requireSiteOwner(userID, siteID); err != nil {
+		return models.CollectionPage{}, err
+	}
+	collectionsDB, total, err := s.Storage.GetCollectionsPage(siteID, limit, (page-1)*limit)
+	if err != nil {
+		return models.CollectionPage{}, err
+	}
+	collections := make([]models.Collection, len(collectionsDB))
+	for index, collection := range collectionsDB {
+		collections[index] = mapToCollection(collection)
+	}
+	return models.CollectionPage{Collections: collections, Pagination: pagination(total, page, limit)}, nil
+}
+
 func (s *Service) DeleteCollection(collectionID, userID string) error {
 	if err := s.requireCollectionOwner(userID, collectionID); err != nil {
 		return err

--- a/internal/services/list_pagination_test.go
+++ b/internal/services/list_pagination_test.go
@@ -1,0 +1,55 @@
+package services
+
+import (
+	"barecms/internal/storage"
+	"fmt"
+	"testing"
+)
+
+func TestSiteAndCollectionPagesAreBounded(t *testing.T) {
+	service := entryTestService(t)
+	for index := 2; index <= 4; index++ {
+		site := storage.SiteDB{ID: fmt.Sprintf("site-%d", index), Name: fmt.Sprintf("Site %d", index), Slug: fmt.Sprintf("site-%d", index), UserID: "owner-1"}
+		if err := service.Storage.CreateSite(site); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sites, err := service.GetSitesPage("owner-1", 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sites.Sites) != 2 || sites.Pagination.Total != 4 || sites.Pagination.TotalPages != 2 {
+		t.Fatalf("unexpected sites page: %+v", sites)
+	}
+
+	for index := 2; index <= 4; index++ {
+		collection := storage.CollectionDB{ID: fmt.Sprintf("collection-%d", index), SiteID: "site-1", Name: fmt.Sprintf("Collection %d", index), Slug: fmt.Sprintf("collection-%d", index)}
+		if err := service.Storage.CreateCollection(collection); err != nil {
+			t.Fatal(err)
+		}
+	}
+	collections, err := service.GetCollectionsPage("site-1", "owner-1", 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(collections.Collections) != 2 || collections.Pagination.Total != 4 || collections.Pagination.TotalPages != 2 {
+		t.Fatalf("unexpected collections page: %+v", collections)
+	}
+}
+
+func TestMediaPageIsBounded(t *testing.T) {
+	service := mediaTestService(t)
+	for index := 1; index <= 3; index++ {
+		file := storage.MediaFileDB{ID: fmt.Sprintf("media-%d", index), SiteID: "site-1", StoredName: fmt.Sprintf("media-%d.png", index), OriginalName: "image.png", MIMEType: "image/png", Size: 1}
+		if err := service.Storage.CreateMediaFile(&file); err != nil {
+			t.Fatal(err)
+		}
+	}
+	page, err := service.ListMediaPage("site-1", "owner-1", 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Files) != 1 || page.Pagination.Total != 3 || page.Pagination.TotalPages != 2 {
+		t.Fatalf("unexpected media page: %+v", page)
+	}
+}

--- a/internal/services/media.go
+++ b/internal/services/media.go
@@ -81,6 +81,21 @@ func (s *Service) ListMedia(siteID, userID string) ([]models.MediaFile, error) {
 	return files, nil
 }
 
+func (s *Service) ListMediaPage(siteID, userID string, page, limit int) (models.MediaFilePage, error) {
+	if err := s.requireSiteOwner(userID, siteID); err != nil {
+		return models.MediaFilePage{}, err
+	}
+	filesDB, total, err := s.Storage.GetMediaFilesPage(siteID, limit, (page-1)*limit)
+	if err != nil {
+		return models.MediaFilePage{}, err
+	}
+	files := make([]models.MediaFile, len(filesDB))
+	for index, file := range filesDB {
+		files[index] = mapToMediaFile(file)
+	}
+	return models.MediaFilePage{Files: files, Pagination: pagination(total, page, limit)}, nil
+}
+
 func (s *Service) GetMedia(id string) (models.MediaFile, string, error) {
 	file, err := s.Storage.GetMediaFile(id)
 	if err != nil {

--- a/internal/services/pagination.go
+++ b/internal/services/pagination.go
@@ -1,0 +1,7 @@
+package services
+
+import "barecms/internal/models"
+
+func pagination(total int64, page, limit int) models.Pagination {
+	return models.Pagination{Page: page, Limit: limit, Total: total, TotalPages: int((total + int64(limit) - 1) / int64(limit))}
+}

--- a/internal/services/sites.go
+++ b/internal/services/sites.go
@@ -27,6 +27,18 @@ func (s *Service) GetSites(userID string) ([]models.Site, error) {
 	return sites, nil
 }
 
+func (s *Service) GetSitesPage(userID string, page, limit int) (models.SitePage, error) {
+	sitesDB, total, err := s.Storage.GetSitesPage(userID, limit, (page-1)*limit)
+	if err != nil {
+		return models.SitePage{}, err
+	}
+	sites := make([]models.Site, len(sitesDB))
+	for index, site := range sitesDB {
+		sites[index] = mapToSite(site)
+	}
+	return models.SitePage{Sites: sites, Pagination: pagination(total, page, limit)}, nil
+}
+
 func (s *Service) GetSite(id, userID string) (models.Site, error) {
 	if err := s.requireSiteOwner(userID, id); err != nil {
 		return models.Site{}, err

--- a/internal/storage/collections.go
+++ b/internal/storage/collections.go
@@ -50,6 +50,16 @@ func (s *Storage) GetCollectionsBySiteID(siteID string) ([]CollectionDB, error) 
 	return collections, nil
 }
 
+func (s *Storage) GetCollectionsPage(siteID string, limit, offset int) ([]CollectionDB, int64, error) {
+	var total int64
+	if err := s.DB.Model(&CollectionDB{}).Where("site_id = ?", siteID).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var collections []CollectionDB
+	err := s.DB.Where("site_id = ?", siteID).Order("id ASC").Limit(limit).Offset(offset).Find(&collections).Error
+	return collections, total, err
+}
+
 func (s *Storage) DeleteCollection(id string) error {
 	tx := s.DB.Begin()
 	if tx.Error != nil {

--- a/internal/storage/media.go
+++ b/internal/storage/media.go
@@ -16,6 +16,16 @@ func (s *Storage) GetMediaFilesBySiteID(siteID string) ([]MediaFileDB, error) {
 	return files, err
 }
 
+func (s *Storage) GetMediaFilesPage(siteID string, limit, offset int) ([]MediaFileDB, int64, error) {
+	var total int64
+	if err := s.DB.Model(&MediaFileDB{}).Where("site_id = ?", siteID).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var files []MediaFileDB
+	err := s.DB.Where("site_id = ?", siteID).Order("created_at DESC, id ASC").Limit(limit).Offset(offset).Find(&files).Error
+	return files, total, err
+}
+
 func (s *Storage) DeleteMediaFile(id string) error {
 	return s.DB.Where("id = ?", id).Delete(&MediaFileDB{}).Error
 }

--- a/internal/storage/sites.go
+++ b/internal/storage/sites.go
@@ -85,6 +85,16 @@ func (s *Storage) GetSitesByUserID(userID string) ([]SiteDB, error) {
 	return sites, nil
 }
 
+func (s *Storage) GetSitesPage(userID string, limit, offset int) ([]SiteDB, int64, error) {
+	var total int64
+	if err := s.DB.Model(&SiteDB{}).Where("user_id = ?", userID).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var sites []SiteDB
+	err := s.DB.Where("user_id = ?", userID).Order("id ASC").Limit(limit).Offset(offset).Find(&sites).Error
+	return sites, total, err
+}
+
 func (s *Storage) UserOwnsSite(userID, siteID string) (bool, error) {
 	var count int64
 	err := s.DB.Model(&SiteDB{}).

--- a/roadmap.md
+++ b/roadmap.md
@@ -48,7 +48,7 @@ The basics every CMS needs. Without these, MCP positioning means nothing.
 - [ ] **API stability**
   - Lock response shapes for sites, collections, entries
   - [x] Bounded pagination and metadata for collection entries (`feature/api-pagination`)
-  - [ ] Pagination on remaining authenticated list endpoints
+  - [x] Pagination on authenticated site, collection, and media lists (`feature/remaining-list-pagination`)
   - [x] Bounded public collection and single-entry endpoints with cache policy (`feature/public-content-api`)
   - [x] Preserve legacy whole-site endpoint compatibility
 - [ ] **Database integrity and migrations**

--- a/ui/src/components/MediaPicker.tsx
+++ b/ui/src/components/MediaPicker.tsx
@@ -21,17 +21,20 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
 }) => {
   const [files, setFiles] = useState<MediaFile[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const { request, loading } = useApi();
 
-  const loadFiles = useCallback(async () => {
+  const loadFiles = useCallback(async (requestedPage = 1) => {
     try {
-      const response = await request({ url: `/sites/${siteId}/files` });
-      setFiles(
-        (response.files || []).filter((file: MediaFile) =>
+      const response = await request({ url: `/sites/${siteId}/files`, params: { page: requestedPage, limit: 50 } });
+      const images = (response.files || []).filter((file: MediaFile) =>
           file.mimeType.startsWith("image/"),
-        ),
-      );
+        );
+      setFiles((current) => requestedPage === 1 ? images : [...current, ...images]);
+      setPage(requestedPage);
+      setTotalPages(response.pagination?.totalPages || 0);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load media");
@@ -39,7 +42,7 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
   }, [request, siteId]);
 
   useEffect(() => {
-    void loadFiles();
+    void loadFiles(1);
   }, [loadFiles]);
 
   const upload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,7 +101,7 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
         </div>
       )}
 
-      {files.length > 0 && (
+      {(files.length > 0 || page < totalPages) && (
         <div>
           <p className="mb-2 text-sm text-bare-600">Or choose an existing image</p>
           <div className="grid max-h-48 grid-cols-3 gap-2 overflow-y-auto">
@@ -115,6 +118,11 @@ const MediaPicker: React.FC<MediaPickerProps> = ({
               </button>
             ))}
           </div>
+          {page < totalPages && (
+            <button type="button" className="btn btn-sm mt-2 w-full" disabled={loading} onClick={() => void loadFiles(page + 1)}>
+              Load more
+            </button>
+          )}
         </div>
       )}
 

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -12,6 +12,11 @@ export class ApiRequestError extends Error {
   }
 }
 
+export const apiErrorMessage = (error: any, fallback: string) => {
+  const apiError = error.response?.data?.error;
+  return (typeof apiError === "string" ? apiError : apiError?.message) || error.message || fallback;
+};
+
 export const useApi = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -25,10 +30,7 @@ export const useApi = () => {
       return response.data;
     } catch (err: any) {
       const apiError = err.response?.data?.error;
-      const errorMessage =
-        (typeof apiError === "string" ? apiError : apiError?.message) ||
-        err.response?.data?.message ||
-        err.message;
+      const errorMessage = apiErrorMessage(err, "Request failed");
       setError(errorMessage);
       throw new ApiRequestError(errorMessage, apiError?.fields || {});
     } finally {

--- a/ui/src/hooks/useCollectionDetail.ts
+++ b/ui/src/hooks/useCollectionDetail.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import apiClient from "@/lib/api";
 import { Collection, Entry, Pagination, Site } from "@/types";
+import { apiErrorMessage } from "@/hooks/useApi";
 
 interface CollectionDetailData {
   collection: Collection;
@@ -44,7 +45,7 @@ export function useCollectionDetail(
           site: siteResponse.data.site
         });
       } catch (err: any) {
-        setError(err.response?.data?.error || 'Failed to fetch collection details');
+        setError(apiErrorMessage(err, "Failed to fetch collection details"));
       } finally {
         setLoading(false);
       }

--- a/ui/src/hooks/useSiteDetail.ts
+++ b/ui/src/hooks/useSiteDetail.ts
@@ -1,16 +1,19 @@
 import { useState, useEffect } from "react";
 import apiClient from "@/lib/api";
-import { Site, Collection } from "@/types";
+import { Site, Collection, Pagination } from "@/types";
+import { apiErrorMessage } from "@/hooks/useApi";
 
 interface SiteDetailData {
   site: Site;
   collections: Collection[];
+  pagination: Pagination;
 }
 
 export function useSiteDetail(siteId: string | undefined) {
   const [data, setData] = useState<SiteDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     if (!siteId) {
@@ -27,26 +30,29 @@ export function useSiteDetail(siteId: string | undefined) {
         // Fetch both site and collections in parallel
         const [siteResponse, collectionsResponse] = await Promise.all([
           apiClient.get(`/sites/${siteId}`),
-          apiClient.get(`/sites/${siteId}/collections`)
+          apiClient.get(`/sites/${siteId}/collections`, { params: { page, limit: 20 } })
         ]);
 
         setData({
           site: siteResponse.data.site,
-          collections: collectionsResponse.data.collections
+          collections: collectionsResponse.data.collections,
+          pagination: collectionsResponse.data.pagination,
         });
       } catch (err: any) {
-        setError(err.response?.data?.error || 'Failed to fetch site details');
+        setError(apiErrorMessage(err, "Failed to fetch site details"));
       } finally {
         setLoading(false);
       }
     };
 
     fetchSiteDetail();
-  }, [siteId]);
+  }, [siteId, page]);
 
   return {
     site: data?.site || null,
     collections: data?.collections || [],
+    pagination: data?.pagination || { page: 1, limit: 20, total: 0, totalPages: 0 },
+    setPage,
     loading,
     error
   };

--- a/ui/src/hooks/useSites.ts
+++ b/ui/src/hooks/useSites.ts
@@ -1,30 +1,37 @@
 import { useState, useEffect } from "react";
 import apiClient from "@/lib/api";
-import { Site } from "@/types";
+import { Pagination, Site } from "@/types";
+import { apiErrorMessage } from "@/hooks/useApi";
 
 interface SitesResponse {
   sites: Site[];
+  pagination: Pagination;
 }
 
 export function useSites() {
   const [sites, setSites] = useState<Site[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState<Pagination>({ page: 1, limit: 20, total: 0, totalPages: 0 });
 
   useEffect(() => {
     const fetchSites = async () => {
       try {
-        const response = await apiClient.get<SitesResponse>('/sites');
+        setLoading(true);
+        setError(null);
+        const response = await apiClient.get<SitesResponse>('/sites', { params: { page, limit: 20 } });
         setSites(response.data.sites);
+        setPagination(response.data.pagination);
       } catch (err: any) {
-        setError(err.response?.data?.error || 'Failed to fetch sites');
+        setError(apiErrorMessage(err, "Failed to fetch sites"));
       } finally {
         setLoading(false);
       }
     };
 
     fetchSites();
-  }, []);
+  }, [page]);
 
-  return { sites, loading, error };
+  return { sites, pagination, setPage, loading, error };
 }

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import Loader from "@/components/Loader";
 
 const HomePage: React.FC = () => {
   const { user, loading: userLoading } = useAuth();
-  const { sites, loading: sitesLoading, error } = useSites();
+  const { sites, pagination, setPage, loading: sitesLoading, error } = useSites();
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const openModal = () => {
@@ -108,6 +108,14 @@ const HomePage: React.FC = () => {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {pagination.totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 mt-8">
+          <button className="btn btn-sm" disabled={pagination.page <= 1} onClick={() => setPage(pagination.page - 1)}>Previous</button>
+          <span className="text-sm text-bare-600">Page {pagination.page} of {pagination.totalPages} · {pagination.total} sites</span>
+          <button className="btn btn-sm" disabled={pagination.page >= pagination.totalPages} onClick={() => setPage(pagination.page + 1)}>Next</button>
         </div>
       )}
 

--- a/ui/src/pages/sites/Detail.tsx
+++ b/ui/src/pages/sites/Detail.tsx
@@ -9,7 +9,7 @@ import CreateSiteModal from "@/components/modals/CreateSiteModal";
 
 const SiteDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { site, collections, loading, error } = useSiteDetail(id);
+  const { site, collections, pagination, setPage, loading, error } = useSiteDetail(id);
   const { isDeleting, handleDelete } = useDelete(`/sites/${id || ""}`, "/");
 
   const collectionModalRef = useRef<HTMLDialogElement>(null);
@@ -193,6 +193,13 @@ const SiteDetailsPage: React.FC = () => {
                 </div>
               </div>
             ))}
+          </div>
+        )}
+        {pagination.totalPages > 1 && (
+          <div className="flex items-center justify-center gap-3 pt-4">
+            <button className="btn btn-sm" disabled={pagination.page <= 1} onClick={() => setPage(pagination.page - 1)}>Previous</button>
+            <span className="text-sm text-bare-600">Page {pagination.page} of {pagination.totalPages} · {pagination.total} collections</span>
+            <button className="btn btn-sm" disabled={pagination.page >= pagination.totalPages} onClick={() => setPage(pagination.page + 1)}>Next</button>
           </div>
         )}
       </div>

--- a/ui/src/providers/AuthProvider.tsx
+++ b/ui/src/providers/AuthProvider.tsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import apiClient from "@/lib/api";
 import { AUTH_TOKEN_KEY, User } from "@/types/auth";
 import { AuthContext, AuthContextType } from "@/contexts/AuthContext";
+import { apiErrorMessage } from "@/hooks/useApi";
 
 interface AuthResponse {
   token?: string;
@@ -57,8 +58,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       return { token, user };
     } catch (error: any) {
       setLoading(false);
-      const errorMessage =
-        error.response?.data?.error || "An error occurred. Please try again.";
+      const errorMessage = apiErrorMessage(error, "An error occurred. Please try again.");
       setError(errorMessage);
       return { error: errorMessage };
     }
@@ -86,8 +86,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       return { token, user };
     } catch (err: any) {
       setLoading(false);
-      const errorMessage =
-        err.response?.data?.error || "An error occurred. Please try again.";
+      const errorMessage = apiErrorMessage(err, "An error occurred. Please try again.");
       setError(errorMessage);
       return { error: errorMessage };
     }


### PR DESCRIPTION
## Summary

- paginate authenticated site lists
- paginate site collection lists
- paginate site media lists
- keep existing resource keys and add consistent pagination metadata
- cap all list limits at 100
- add previous/next controls for sites and collections
- add incremental media loading to the image picker
- handle media pages containing only non-image files
- normalize structured error messages across auth and data hooks
- document authenticated pagination and complete the API pagination roadmap item

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Tests added

- bounded site pages and totals
- bounded collection pages and totals
- bounded media pages and totals
